### PR TITLE
Return just the features file base name not its full path when creating HTML output for features.

### DIFF
--- a/dark/html.py
+++ b/dark/html.py
@@ -203,11 +203,13 @@ span.reads {
 
         @param i: The number of the image in self._images.
         @param image: A member of self._images.
-        @return: The C{str} features file name.
+        @return: The C{str} features file name - just the base name, not
+            including the path to the file.
         """
-        filename = '%s/features-%d.txt' % (self._outputDir, i)
+        basename = 'features-%d.txt' % i
+        filename = '%s/%s' % (self._outputDir, basename)
         featureList = image['alignmentInfo']['features']
         with open(filename, 'w') as fp:
             for feature in featureList:
                 fp.write('%s\n\n' % feature.feature)
-        return filename
+        return basename


### PR DESCRIPTION
Fixes #133
