### PR TITLE
Added filtering on reads to the BlastRecords.records function, moving some of it out of computePlotInfo

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -61,7 +61,16 @@ if __name__ == '__main__':
     parser.add_argument(
         '--db', type=str, default='nt', help='the BLAST db that was used')
 
-    # Args for the interesting selection.
+    # Args for filtering reads and titles.
+    parser.add_argument(
+        '--oneAlignmentPerRead', default=False, action='store_true',
+        help='If C{True}, only keep the best alignment for each read.')
+
+    parser.add_argument(
+        '--bitScoreCutoff', type=float, default=None,
+        help=('A float bit score. Hits with bit scores less than '
+              'this will be ignored.'))
+
     parser.add_argument(
         '--whitelist', type=str, nargs='+', default=None,
         help='sequence titles that should be whitelisted')
@@ -196,6 +205,11 @@ if __name__ == '__main__':
     blastRecords = BlastRecords(args.json, fastaFilename=args.fasta,
                                 blastDb=args.db)
 
+    records = blastRecords.records(
+        oneAlignmentPerRead=args.oneAlignmentPerRead,
+        maxHspsPerHit=args.maxHspsPerHit, bitScoreCutoff=args.bitScoreCutoff,
+        eCutoff=args.eCutoff)
+
     # Convert white/blacklists lists to sets.
     if args.whitelist is not None:
         args.whitelist = set(args.whitelist)
@@ -203,6 +217,7 @@ if __name__ == '__main__':
         args.blacklist = set(args.blacklist)
 
     hits = blastRecords.filterHits(
+        records=records,
         whitelist=args.whitelist,
         blacklist=args.blacklist,
         minSequenceLen=args.minSequenceLen,
@@ -232,7 +247,6 @@ if __name__ == '__main__':
         sys.exit(0)
 
     hits.computePlotInfo(
-        eCutoff=args.eCutoff, maxHspsPerHit=args.maxHspsPerHit,
         minStart=args.minStart, maxStop=args.maxStop,
         rankValues=args.rankValues)
 


### PR DESCRIPTION
Fixes #173
