### PR TITLE
Remove an incorrect output file if reads.save raises a ValueError when writing sequences.

### DIFF
--- a/dark/reads.py
+++ b/dark/reads.py
@@ -1,3 +1,4 @@
+from os import unlink
 from Bio.Seq import translate
 from Bio.Data.IUPACData import (
     ambiguous_dna_complement, ambiguous_rna_complement)
@@ -240,9 +241,13 @@ class Reads(object):
         format_ = format_.lower()
 
         if isinstance(filename, basestring):
-            with open(filename, 'w') as fp:
-                for read in self:
-                    fp.write(read.toString(format_))
+            try:
+                with open(filename, 'w') as fp:
+                    for read in self:
+                        fp.write(read.toString(format_))
+            except ValueError:
+                unlink(filename)
+                raise
         else:
             # We have a file-like object.
             for read in self:

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from mock import patch, call
 from cStringIO import StringIO
+from os import stat
 
 from mocking import mockOpen
 from dark.reads import Read, TranslatedRead, Reads, DNARead, RNARead, AARead
@@ -548,6 +549,9 @@ class TestReads(TestCase):
         reads.add(read2)
         error = "Format must be either 'fasta' or 'fastq'\\."
         self.assertRaisesRegexp(ValueError, error, reads.save, 'file', 'xxx')
+        # The output file must not exist following the save() failure.
+        error = "No such file or directory: 'file'"
+        self.assertRaisesRegexp(OSError, error, stat, 'file')
 
     def testSaveFASTAIsDefault(self):
         """
@@ -627,6 +631,9 @@ class TestReads(TestCase):
         reads.add(read2)
         error = "Read 'id2' has no quality information"
         self.assertRaisesRegexp(ValueError, error, reads.save, 'file', 'fastq')
+        # The output file must not exist following the save() failure.
+        error = "No such file or directory: 'file'"
+        self.assertRaisesRegexp(OSError, error, stat, 'file')
 
     def testSaveToFileDescriptor(self):
         """


### PR DESCRIPTION
Fixes #228 
