### PR TITLE
Compress XML after converting to JSON in post-process.sh

### DIFF
--- a/bin/convert-blast-xml-to-json.py
+++ b/bin/convert-blast-xml-to-json.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python
 
+import sys
+from os.path import basename
+
+from dark.blast.conversion import XMLRecordsReader
+
 if __name__ == '__main__':
-    from dark.blast.conversion import XMLRecordsReader
-    import sys
-    if len(sys.argv) == 2:
+    nArgs = len(sys.argv)
+    if nArgs == 1:
+        reader = XMLRecordsReader(sys.stdin)
+        reader.saveAsJSON(sys.stdout)
+    elif nArgs == 2:
         reader = XMLRecordsReader(sys.argv[1])
         reader.saveAsJSON(sys.stdout)
-    elif len(sys.argv) == 3:
+    elif nArgs == 3:
         reader = XMLRecordsReader(sys.argv[1])
         with open(sys.argv[2], 'w') as fp:
             reader.saveAsJSON(fp)
     else:
-        print >>sys.stderr, 'Usage: %s infile.xml [outfile.json]' % sys.argv[0]
+        print >>sys.stderr, (
+            'Usage: %s [infile.xml [outfile.json]]' % basename(sys.argv[0]))
         sys.exit(1)

--- a/bin/write-htcondor-job-spec.py
+++ b/bin/write-htcondor-job-spec.py
@@ -176,9 +176,21 @@ export PYTHONPATH=$DM/dark-matter
 for i in "$@"
 do
     errs=$i.post-process-error
-    $DM/virtualenv/bin/python \
-        $DM/dark-matter/bin/convert-blast-xml-to-json.py \
-        $i.xml 2>$errs | bzip2 > $i.json.bz2
+
+    if [ -f $i.xml ]
+    then
+        $DM/virtualenv/bin/python \
+            $DM/dark-matter/bin/convert-blast-xml-to-json.py \
+            < $i.xml 2>$errs | bzip2 > $i.json.bz2
+        bzip2 $i.xml
+    elif [ -f $i.xml.bz2 ]
+    then
+        bzcat $i.xml.bz2 | $DM/virtualenv/bin/python \
+            $DM/dark-matter/bin/convert-blast-xml-to-json.py \
+            2>$errs | bzip2 > $i.json.bz2
+    else
+        echo "Neither $i.xml nor $i.xml.bz2 existed." > $errs
+    fi
     if [ -s $errs ]
     then
         echo "Completed WITH ERRORS ($errs) on `hostname` at `date`." > $i.done

--- a/dark/blast/conversion.py
+++ b/dark/blast/conversion.py
@@ -3,6 +3,7 @@ from json import dumps, loads
 from operator import itemgetter
 
 from Bio.Blast import NCBIXML
+from Bio.File import as_handle
 
 from dark.hsp import HSP, LSP
 from dark.score import HigherIsBetterScore
@@ -16,7 +17,8 @@ class XMLRecordsReader(object):
     make accessible the global BLAST parameters.
 
     @ivar params: A C{dict} of global BLAST parameters.
-    @param filename: A C{str} filename containing XML BLAST records.
+    @param filename: A C{str} filename or an open file pointer, containing XML
+        BLAST records.
     """
 
     def __init__(self, filename):
@@ -138,7 +140,7 @@ class XMLRecordsReader(object):
         method. Set self.params from data in the first record.
         """
         first = True
-        with open(self._filename) as fp:
+        with as_handle(self._filename) as fp:
             for record in NCBIXML.parse(fp):
                 if first:
                     self.params = self._convertBlastParamsToDict(record)


### PR DESCRIPTION
Also, convert-blast-xml-to-json.py can now (also) work as a filter (reading stdin, writing stdout).

Fixes #305 
