### PR TITLE
Added compress option to convert-blast-xml-to-json.py

### DIFF
--- a/bin/convert-blast-xml-to-json.py
+++ b/bin/convert-blast-xml-to-json.py
@@ -1,23 +1,48 @@
 #!/usr/bin/env python
 
+import argparse
+import bz2
 import sys
-from os.path import basename
 
 from dark.blast.conversion import XMLRecordsReader
 
+
 if __name__ == '__main__':
-    nArgs = len(sys.argv)
-    if nArgs == 1:
-        reader = XMLRecordsReader(sys.stdin)
-        reader.saveAsJSON(sys.stdout)
-    elif nArgs == 2:
-        reader = XMLRecordsReader(sys.argv[1])
-        reader.saveAsJSON(sys.stdout)
-    elif nArgs == 3:
-        reader = XMLRecordsReader(sys.argv[1])
-        with open(sys.argv[2], 'w') as fp:
+
+    parser = argparse.ArgumentParser(
+        description='Convert a BLAST XML file to JSON.',
+        epilog='Give a BLAST XML file and convert it to JSON. Optionally '
+        'compress the JOSN output file.'
+    )
+
+    parser.add_argument(
+        'xml', metavar='BLAST-XML-file', type=str, help='the XML file of '
+        'BLAST output.')
+
+    parser.add_argument(
+        'json', metavar='BLAST-JSON-file', type=str, nargs='?',
+        help='the JSON filename where contents of "xml" should be written to.')
+
+    parser.add_argument(
+        '--compress', default=False, action='store_true',
+        help='If True, compress the json output.')
+
+    args = parser.parse_args()
+
+    if args.compress:
+        if args.json:
+            reader = XMLRecordsReader(args.xml)
+            fp = bz2.BZ2File(args.json, 'w')
             reader.saveAsJSON(fp)
+            fp.close()
+        else:
+            raise ValueError('JSON filename must be specified if output '
+                             'should be compressed.')
     else:
-        print >>sys.stderr, (
-            'Usage: %s [infile.xml [outfile.json]]' % basename(sys.argv[0]))
-        sys.exit(1)
+        if args.json:
+            reader = XMLRecordsReader(args.xml)
+            with open(args.json, 'w') as fp:
+                reader.saveAsJSON(fp)
+        else:
+            reader = XMLRecordsReader(args.xml)
+            reader.saveAsJSON(sys.stdout)

--- a/bin/convert-blast-xml-to-json.py
+++ b/bin/convert-blast-xml-to-json.py
@@ -30,22 +30,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.bzip2:
-        if args.json:
-            reader = XMLRecordsReader(args.xml)
-            fp = bz2file.BZ2File(args.json, 'w')
-            reader.saveAsJSON(fp)
-            fp.close()
-        else:
-            reader = XMLRecordsReader(args.xml)
-            fp = bz2file.BZ2File(sys.stdout, 'w')
-            reader.saveAsJSON(fp)
-            fp.close()
-
+        fp = bz2file.BZ2File(args.json or sys.stdout, 'w')
     else:
-        if args.json:
-            reader = XMLRecordsReader(args.xml)
-            with open(args.json, 'w') as fp:
-                reader.saveAsJSON(fp)
-        else:
-            reader = XMLRecordsReader(args.xml)
-            reader.saveAsJSON(sys.stdout)
+        fp = open(args.json, 'w') if args.json else sys.stdout
+
+    reader = XMLRecordsReader(args.xml)
+    reader.saveAsJSON(fp)
+    fp.close()

--- a/bin/convert-blast-xml-to-json.py
+++ b/bin/convert-blast-xml-to-json.py
@@ -16,11 +16,12 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        'xml', metavar='BLAST-XML-file', help='the XML file of BLAST output.')
-
-    parser.add_argument(
         'json', metavar='BLAST-JSON-file', nargs='?',
         help='the JSON filename where contents of "xml" should be written to.')
+
+    parser.add_argument(
+        '--xml', metavar='BLAST-XML-file', default=sys.stdin,
+        help='the XML file of BLAST output.')
 
     parser.add_argument(
         '--bzip2', default=False, action='store_true',

--- a/bin/convert-blast-xml-to-json.py
+++ b/bin/convert-blast-xml-to-json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import bz2
+import bz2file
 import sys
 
 from dark.blast.conversion import XMLRecordsReader
@@ -12,32 +12,34 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Convert a BLAST XML file to JSON.',
         epilog='Give a BLAST XML file and convert it to JSON. Optionally '
-        'compress the JOSN output file.'
+        'compress the JOSN output.'
     )
 
     parser.add_argument(
-        'xml', metavar='BLAST-XML-file', type=str, help='the XML file of '
-        'BLAST output.')
+        'xml', metavar='BLAST-XML-file', help='the XML file of BLAST output.')
 
     parser.add_argument(
-        'json', metavar='BLAST-JSON-file', type=str, nargs='?',
+        'json', metavar='BLAST-JSON-file', nargs='?',
         help='the JSON filename where contents of "xml" should be written to.')
 
     parser.add_argument(
-        '--compress', default=False, action='store_true',
-        help='If True, compress the json output.')
+        '--bzip2', default=False, action='store_true',
+        help='If True, compress the json output using bzip2.')
 
     args = parser.parse_args()
 
-    if args.compress:
+    if args.bzip2:
         if args.json:
             reader = XMLRecordsReader(args.xml)
-            fp = bz2.BZ2File(args.json, 'w')
+            fp = bz2file.BZ2File(args.json, 'w')
             reader.saveAsJSON(fp)
             fp.close()
         else:
-            raise ValueError('JSON filename must be specified if output '
-                             'should be compressed.')
+            reader = XMLRecordsReader(args.xml)
+            fp = bz2file.BZ2File(sys.stdout, 'w')
+            reader.saveAsJSON(fp)
+            fp.close()
+
     else:
         if args.json:
             reader = XMLRecordsReader(args.xml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 biopython==1.64
+bz2file==0.98
 discover==0.4.0
 ipython==2.2.0
 matplotlib==1.3.1


### PR DESCRIPTION
If you want to compress the output use:

```sh
$ convert-blast-xml-to-json.py filename.xml filename.json.bz2 --compress
```

Fixes #308 