### PR TITLE
Convert GOR4 to run under cffi instead of Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ dist
 dark_matter.egg-info
 *.o
 *.so
-src/gor4/gor4.c

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: check, pep8, pyflakes, lint
 
-check: dark/gor4.so
+check: dark/_gor4.so
 	python -m discover -v
 
-tcheck: dark/gor4.so
+tcheck: dark/_gor4.so
 	trial --rterrors test
 
-dark/gor4.so: $(wildcard src/gor4/*.c src/gor4/*.h src/gor4/*.pxd src/gor4/*.pyx)
+dark/_gor4.so: $(wildcard src/gor4/*.c src/gor4/*.h src/gor4/build.py)
 	python setup.py build_ext -i
 
 pep8:
@@ -24,5 +24,6 @@ clean:
 	find . \( -name '*.pyc' -o -name '*~' \) -print0 | xargs -0 rm
 	find . -name '__pycache__' -type d -print0 | xargs -0 rmdir
 	find . -name '_trial_temp' -type d -print0 | xargs -0 rm -r
-	rm -fr dark_matter.egg-info build dist dark/gor4.so src/gor4/gor4.c
-	rm -f dark/gor4.cpython-35m-darwin.so
+	rm -f dark/_gor4.*
+	rm -fr dark_matter.egg-info
+	python setup.py clean

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Requires Python 2.7 to 3.5.
 
 ## Installation
 
-[Linux](doc/linux.md), [Windows](doc/windows.md).
+[Linux](doc/linux.md), [OS X](doc/mac.md), [Windows](doc/windows.md).

--- a/dark/entrez.py
+++ b/dark/entrez.py
@@ -1,5 +1,4 @@
 from Bio import Entrez, SeqIO
-# from urllib.error import URLError
 from six.moves.urllib_error import URLError
 
 Entrez.email = 'tcj25@cam.ac.uk'

--- a/dark/summarize.py
+++ b/dark/summarize.py
@@ -1,6 +1,8 @@
 from Bio import SeqIO
 from collections import defaultdict
 
+from dark.utils import median
+
 
 def summarizeReads(file_handle, file_type):
     """
@@ -22,17 +24,6 @@ def summarizeReads(file_handle, file_type):
         length_list.append(len(record))
         for base in record:
             base_counts[base] += 1
-
-    def median(length_list):
-        my_list = sorted(length_list)
-        list_count = len(length_list)
-        if list_count % 2 != 0:
-            index_middle_number = (list_count - 1) // 2
-            return my_list[index_middle_number]
-        else:
-            first_number = my_list[list_count // 2]
-            second_number = my_list[(list_count // 2) - 1]
-            return (first_number + second_number) / 2.0
 
     result = {
         "read_number": read_number,

--- a/dark/titles.py
+++ b/dark/titles.py
@@ -1,7 +1,7 @@
-import numpy as np
 from collections import defaultdict, Counter
 
 from dark.reads import Reads
+from dark.utils import median
 from dark.filter import ReadSetFilter
 from dark.intervals import ReadIntervals
 
@@ -107,6 +107,7 @@ class TitleAlignments(list):
         """
         Find the HSP with the best score.
 
+        @raise ValueError: If there are no HSPs.
         @return: The C{dark.hsp.HSP} instance (or a subclass) with the best
         score.
         """
@@ -116,6 +117,7 @@ class TitleAlignments(list):
         """
         Find the HSP with the worst score.
 
+        @raise ValueError: If there are no HSPs.
         @return: The C{dark.hsp.HSP} instance (or a subclass) with the worst
         score.
         """
@@ -138,13 +140,14 @@ class TitleAlignments(list):
 
     def medianScore(self):
         """
-        Find out the median score for the HSPs in the alignments that match
+        Find the median score for the HSPs in the alignments that match
         this title.
 
+        @raise ValueError: If there are no HSPs.
         @return: The C{float} median score of HSPs in alignments matching the
             title.
         """
-        return np.median([hsp.score.score for hsp in self.hsps()])
+        return median([hsp.score.score for hsp in self.hsps()])
 
     def coverage(self):
         """

--- a/dark/utils.py
+++ b/dark/utils.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import string
 from os.path import basename
 
@@ -31,3 +33,65 @@ def numericallySortFilenames(names):
         return 0 if count == 0 else int(name[0:count])
 
     return sorted(names, key=lambda name: numericPrefix(basename(name)))
+
+
+# Set up a median function that works on different Python versions and on pypy
+# (even if numpypy is still broken).
+#
+# First try numpy, and check that an ndarray has a partition method (to avoid a
+# shortcoming in pypy numpy, see
+# https://bitbucket.org/pypy/numpy/issues/12/median-calling-ndarraypartition
+# If numpy seems ok, use it. Else try for the Python 3.4 median function, else
+# write our own.
+
+import numpy as np
+_a = np.array([1])
+
+try:
+    _a.partition
+except AttributeError:
+    # Cannot use numpy. Try for the new (Python 3.4) built-in function.
+    try:
+        from statistics import median as _median
+    except ImportError:
+        def _median(l):
+            """
+            Find the median of a set of numbers.
+
+            @param l: A C{list} of numeric values.
+            @return: The median value in C{l}.
+            """
+            l = sorted(l)
+            n = len(l)
+            if n % 2:
+                return l[n // 2]
+            else:
+                n //= 2
+                return (l[n - 1] + l[n]) / 2
+else:
+    # We have a working numpy. Just make sure we raise on an empty list as
+    # numpy returns numpy.nan
+    _median = np.median
+
+del _a
+
+
+def median(l):
+    """
+    Find the median of a set of numbers.
+
+    @param l: A C{list} of numeric values.
+    @raise ValueError: If C{l} is empty.
+    @return: The median value in C{l}.
+    """
+
+    # Handle the zero length case ahead of time because various median
+    # implementations do different things. numpy returns nan, whereas Python
+    # 3.4 and later raise StatisticsError
+
+    if len(l) == 0:
+        # Match the empty-argument exception message of Python's built-in max
+        # and min functions.
+        raise ValueError('arg is an empty sequence')
+    else:
+        return _median(l)

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -1,0 +1,66 @@
+## Installation on OS X
+
+The following works on OS X 10.10.5 (Yosemite)
+
+# Using Brew and virtualenv
+
+First of all, install [brew](http://brew.sh/) if you don't have it already.
+Then use brew to install [virtualenv](https://pypi.python.org/pypi/virtualenv).
+
+```sh
+$ brew install pyenv-virtualenv
+```
+
+## Create a Python virtual environment
+
+```sh
+$ virtualenv env
+$ . env/bin/activate
+```
+
+## Get the dark matter sources
+
+You can either download a stable (and possibly slightly old) version of
+dark matter from PyPI using pip:
+
+```sh
+$ pip install dark-matter
+$ cd dark-matter
+$ pip install -r requirements.txt
+```
+
+Or, clone the dark matter github repo to have the very latest code:
+
+```sh
+$ git clone https://github.com/acorg/dark-matter
+$ cd dark-matter
+$ python setup.py install
+```
+
+In this latter case, you may want to add the `dark-matter` directory (the
+one created above by `git clone`) to your shell's `PYTHONPATH`.
+
+# Using pypy
+
+Things are a little more awkward to set up using pypy, due to the building
+of matplotlib. Here are instructions for brew and virtualenv (first install
+those two and make and activate a virtualenv):
+
+```sh
+$ git clone https://github.com/acorg/dark-matter
+$ cd dark-matter
+$ python setup.py install
+$ pip install -r requirements.txt
+```
+
+Then install a pypy-specific version of matplotlib:
+
+```sh
+$ git clone git@github.com:mattip/matplotlib.git  # This might take a while
+$ cd matplotlib
+$ python setup.py install
+```
+
+# Install a taxonomy database (optional)
+
+See [taxonomy.md](taxonomy.md) for details.

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -23,6 +23,9 @@ $ . env/bin/activate
 You can either download a stable (and possibly slightly old) version of
 dark matter from PyPI using pip:
 
+Note that if you are using Python 2, use `requirements2.txt` in the
+following.
+
 ```sh
 $ pip install dark-matter
 $ cd dark-matter
@@ -50,10 +53,10 @@ those two and make and activate a virtualenv):
 $ git clone https://github.com/acorg/dark-matter
 $ cd dark-matter
 $ python setup.py install
-$ pip install -r requirements.txt
+$ pip install -r requirements-pypy.txt
 ```
 
-Then install a pypy-specific version of matplotlib:
+Then install the pypy-specific version of matplotlib:
 
 ```sh
 $ git clone git@github.com:mattip/matplotlib.git  # This might take a while

--- a/requirements-pypy.txt
+++ b/requirements-pypy.txt
@@ -1,10 +1,8 @@
+git+http://bitbucket.org/pypy/numpy.git
 biopython==1.64
-bz2file==0.98
-cython==0.21.2
 discover==0.4.0
-ipython==3.1.0
-matplotlib==1.4.3
-numpy==1.8.1
+ipython==2.2.0
+mock==1.0.1
 pandas==0.14.1
 pep8==1.5.7
 pyflakes==0.8.1
@@ -12,6 +10,7 @@ pyzmq==14.3.1
 reportlab==3.1.44
 simplejson==3.5.3
 tornado==4.0.1
+MySQL-python==1.2.5
+Twisted==15.5.0
 --allow-external mysql-connector-python
 mysql-connector-python==2.0.3
-Twisted==15.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from distutils.extension import Extension
-from Cython.Build import cythonize
 
 # Explicitly list bin scripts to be installed, seeing as I have a few local
 # bin files that are not (yet) part of the distribution.
 scripts = [
+    'bin/aa-info.py',
+    'bin/aa-to-properties.py',
     'bin/adaptor-distances.py',
     'bin/alignments-per-read.py',
+    'bin/bit-score-to-e-value.py',
     'bin/cat-json-blast-records.py',
     'bin/check-fasta-json-blast-consistency.py',
+    'bin/codon-distance.py',
     'bin/convert-blast-xml-to-json.py',
     'bin/convert-fasta-to-one-sequence-per-line.py',
+    'bin/convert-fastq-to-fasta.py',
+    'bin/convert-sam-to-fastq.sh',
+    'bin/dna-to-aa.py',
+    'bin/e-value-to-bit-score.py',
+    'bin/extract-ORFs.py',
     'bin/fasta-subset.py',
     'bin/fasta-subtraction.py',
-    'bin/filter-fasta-by-length.py',
+    'bin/filter-fasta-by-complexity.py',
+    'bin/filter-fasta-by-taxonomy.py',
+    'bin/filter-fasta.py',
     'bin/filter-hits-to-fasta.py',
     'bin/find-hits.py',
     'bin/get-features.py',
@@ -23,10 +32,12 @@ scripts = [
     'bin/graph-evalues.py',
     'bin/local-align.py',
     'bin/noninteractive-alignment-panel.py',
+    'bin/position-summary.py',
     'bin/pre-commit.sh',
     'bin/print-blast-xml-for-derek.py',
     'bin/print-blast-xml.py',
     'bin/print-read-lengths.py',
+    'bin/randomize-fasta.py',
     'bin/read-blast-json.py',
     'bin/read-blast-xml.py',
     'bin/sff-to-fastq.py',
@@ -38,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.1',
+      version='1.0.2',
       packages=['dark'],
       url='https://github.com/acorg/dark-matter',
       download_url='https://github.com/acorg/dark-matter',
@@ -54,11 +65,10 @@ setup(name='dark-matter',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
       license='MIT',
-      description=('Python classes to help with virus discovery from genetic '
-                   'sequence data'),
+      description='Python classes for working with genetic sequence data',
       scripts=scripts,
-      ext_modules=cythonize([
-          Extension('dark.gor4',
-                    ['src/gor4/gor4.pyx', 'src/gor4/gor4-base.c',
-                     'src/gor4/nrutil.c', 'src/gor4/api.c'])]
-      ))
+      install_requires=['cffi>=1.0.0'],
+      setup_requires=['cffi>=1.0.0'],
+      cffi_modules=[
+          './src/gor4/build.py:ffi',
+      ])

--- a/src/gor4/README.md
+++ b/src/gor4/README.md
@@ -14,7 +14,8 @@ change that, or to otherwise clean up the code, tempting as it has been.
 
 ## Python interface
 
-I used [Cython](http://cython.org/) to make a Python interface to GOR IV.
+I used [cffi](https://cffi.readthedocs.org/en/latest/index.html) to make a
+Python interface to GOR IV.
 
 Usage is as follows:
 
@@ -43,13 +44,11 @@ The files in this directory are as follows:
   `struct` containing pointers to `malloc`d memory that is `free`d in
   `finalize`. To get a secondary structure prediction, `predict` must be
   called.
-* `cgor4.pxd`: Cython declarations based on `gor4-base.h`.
+* `build.py`: Python to tell `cffi` how to build the module, and what functions
+  are available.
 * `gor4-base.c`: A very slightly modified copy of the original `gor.c` file.  The
   modification is that some `#define` constants have been moved into `gor4-base.h`
   so they can also be used in `api.c`.
 * `gor4-base.h`: Some `#define` constants that used to be in `gor4-base.c`, plus
   the definition of the `struct` returned by `initialize`.
-* `gor4.pyx`: The Cython interface definition. Note that this has to muck around
-  with arguments to give to and receive from the underling GOR IV code the 1-based
-  memory structures it expects.
 * `nrutil.{c,h}`: The original files from the GOR IV distribution.

--- a/src/gor4/api.c
+++ b/src/gor4/api.c
@@ -2,8 +2,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _CFFI_
+#include "defines.h"
 #include "nrutil.h"
 #include "gor4-base.h"
+#endif
 
 /* Functions in gor.c */
 extern void Parameters(int nprot_dbase, int *nres, char **obs, char **seq);
@@ -37,7 +40,7 @@ countProteins(char *filename)
     return n;
 }
 
-static int
+int
 read_file(char *fname, int nprot, char **obs, char **title, int *pnter)
 {
     FILE *fp;

--- a/src/gor4/build.py
+++ b/src/gor4/build.py
@@ -1,0 +1,32 @@
+from os.path import join, dirname
+
+from cffi import FFI
+
+
+def fileToString(filename):
+    """
+    Read a file's contents and return it as a string.
+
+    @param filename: A C{str} file name.
+    @return: A C{str} containing the contents of the file.
+    """
+    with open(join(dirname(__file__), filename)) as f:
+        s = f.read()
+    return s
+
+
+ffi = FFI()
+
+header = fileToString('gor4-base.h')
+
+ffi.set_source('dark._gor4', header +
+               fileToString('defines.h') +
+               fileToString('nrutil.h') +
+               fileToString('nrutil.c') +
+               fileToString('gor4-base.c') +
+               fileToString('api.c'))
+
+ffi.cdef(header)
+
+if __name__ == '__main__':
+    ffi.compile()

--- a/src/gor4/cgor4.pxd
+++ b/src/gor4/cgor4.pxd
@@ -1,8 +1,0 @@
-cdef extern from "gor4-base.h":
-    ctypedef struct State:
-        char *predi
-        float **probai
-
-    State *initialize(char *sequenceFilename, char *secondaryFilename, int *error)
-    void finalize(State *state)
-    void predict(State *state, char *sequence)

--- a/src/gor4/defines.h
+++ b/src/gor4/defines.h
@@ -1,0 +1,14 @@
+#define LSIZE 500
+#define BUFSIZE 10000
+#define MAXRES 1200
+#define MAXLINE 150
+#define DISLOCATION 8
+#define OFFSET 9        /* DISLOCATION+1 */
+#define WINSIZ 17       /* 2*DISLOCATION+1 */
+#define NPAIRS 136      /* WINSIZ*(WINSIZ-1)/2 */
+#define BLANK 21        /* The index of the character '^' in array amino */
+#define interpol_coeff 0.75
+#define MINFREQ 10.
+#define SKIP_BLANK 0
+#define Nterm 3
+#define Cterm 2

--- a/src/gor4/gor4-base.h
+++ b/src/gor4/gor4-base.h
@@ -1,18 +1,3 @@
-#define LSIZE 500
-#define BUFSIZE 10000
-#define MAXRES 1200
-#define MAXLINE 150
-#define DISLOCATION 8
-#define OFFSET 9        /* DISLOCATION+1 */
-#define WINSIZ 17       /* 2*DISLOCATION+1 */
-#define NPAIRS 136      /* WINSIZ*(WINSIZ-1)/2 */
-#define BLANK 21        /* The index of the character '^' in array amino */
-#define interpol_coeff 0.75
-#define MINFREQ 10.
-#define SKIP_BLANK 0
-#define Nterm 3
-#define Cterm 2
-
 typedef struct {
     char **seq;
     char **obs;

--- a/test/test_mutations.py
+++ b/test/test_mutations.py
@@ -1,5 +1,6 @@
 import six
 from unittest import TestCase
+
 from dark.mutations import getAPOBECFrequencies, mutateString
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
+import six
 from unittest import TestCase
 
-from dark.utils import numericallySortFilenames
+from dark.utils import numericallySortFilenames, median
 
 
 class TestNumericallySortFilenames(TestCase):
@@ -58,3 +59,46 @@ class TestNumericallySortFilenames(TestCase):
             numericallySortFilenames(
                 ['../output/3.json', '../output/21.json', '../output/35.json',
                  '../output/250.json', '../output/2.json']))
+
+
+class TestMedian(TestCase):
+    """
+    Tests for the median function.
+    """
+
+    def testEmptyArgRaises(self):
+        """
+        An empty list must cause median to raise ValueError.
+        """
+        error = '^arg is an empty sequence$'
+        six.assertRaisesRegex(self, ValueError, error, median, [])
+
+    def testMedianOfOne(self):
+        """
+        The median function must work on a list of length one.
+        """
+        self.assertEqual(3, median([3]))
+
+    def testMedianOfTwo(self):
+        """
+        The median function must work on a list of length two.
+        """
+        self.assertEqual(4.5, median([3.1, 5.9]))
+
+    def testMedianOfThree(self):
+        """
+        The median function must work on a list of length threee.
+        """
+        self.assertEqual(5.9, median([3.1, 7.6, 5.9]))
+
+    def testMedianOfFour(self):
+        """
+        The median function must work on a list of length four.
+        """
+        self.assertEqual(4.5, median([3.1, 1.3, 7.6, 5.9]))
+
+    def testMedianOfFive(self):
+        """
+        The median function must work on a list of length five.
+        """
+        self.assertEqual(5.9, median([3.1, 1.3, 7.6, 9.9, 5.9]))


### PR DESCRIPTION
This is based on #332, which should be reviewed & merged first.

Made GOR4 run under cffi instead of Cython.

Also: Added (not very good) install doc for OS X. Added a median function (and tests) that works under python 2, 3, and pypy. There are 2 test errors running under pypy which I think we should fix in another branch (they are due to virtualenv creating a non-framework version of Python, which causes matplotlib to fail on import).

Fixes #333.
