### PR TITLE
Ignore the alphabet when running filter-fasta.py

### DIFF
--- a/bin/filter-fasta.py
+++ b/bin/filter-fasta.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     kept = 0
-    reads = FastaReads(sys.stdin)
+    reads = FastaReads(sys.stdin, checkAlphabet=False)
 
     for seq in reads.filter(
             minLength=args.minLength,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.10',
+      version='1.0.11',
       packages=['dark'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
Well, that was easy :-)

Fixes #345.