### PR TITLE
Added a modifier argument to dark.reads.Reads.filter

### DIFF
--- a/dark/reads.py
+++ b/dark/reads.py
@@ -498,7 +498,7 @@ class Reads(object):
                whitelist=None, blacklist=None,
                titleRegex=None, negativeTitleRegex=None,
                truncateTitlesAfter=None, indices=None, head=None,
-               removeDuplicates=False):
+               removeDuplicates=False, modifier=None):
         """
         Filter a set of reads to produce a matching subset.
 
@@ -525,6 +525,11 @@ class Reads(object):
         @param head: If not C{None}, the C{int} number of sequences at the
             start of the reads to return. Later sequences are skipped.
         @param removeDuplicates: If C{True} remove duplicated sequences.
+        @param modifier: If not C{None} a function that is passed a read
+            and which either returns a read or C{None}. If it returns a read,
+            that read is passed through the filter. If it returns C{None},
+            the read is omitted. Such a function can be used to do customized
+            filtering, to change sequence ids, etc.
         @return: A generator that yields C{Read} instances.
         """
         if (whitelist or blacklist or titleRegex or negativeTitleRegex or
@@ -565,6 +570,13 @@ class Reads(object):
                 if read.sequence in sequencesSeen:
                     continue
                 sequencesSeen.add(read.sequence)
+
+            if modifier:
+                modified = modifier(read)
+                if modified is None:
+                    continue
+                else:
+                    read = modified
 
             yield read
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.13',
+      version='1.0.14',
       packages=['dark'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -1799,6 +1799,59 @@ class TestReads(TestCase):
         result = reads.filter(removeDuplicates=True)
         self.assertEqual([read1], list(result))
 
+    def testFilterWithModifierThatOmits(self):
+        """
+        Filtering with a modifier function must work correctly if the modifier
+        returns C{None} for some reads.
+        """
+        def modifier(read):
+            if read.id == 'id1':
+                return read
+
+        reads = Reads()
+        read1 = Read('id1', 'ATCG')
+        read2 = Read('id2', 'ATCG')
+        reads.add(read1)
+        reads.add(read2)
+        result = reads.filter(modifier=modifier)
+        self.assertEqual([read1], list(result))
+
+    def testFilterWithModifierThatChangesIds(self):
+        """
+        Filtering with a modifier function must work correctly if the modifier
+        changes the ids of reads.
+        """
+        def modifier(read):
+            read.id = read.id.upper()
+            return read
+
+        reads = Reads()
+        read1 = Read('id1', 'ATCG')
+        read2 = Read('id2', 'ATCG')
+        reads.add(read1)
+        reads.add(read2)
+        result = reads.filter(modifier=modifier)
+        self.assertEqual([Read('ID1', 'ATCG'), Read('ID2', 'ATCG')],
+                         list(result))
+
+    def testFilterWithModifierThatOmitsAndChangesIds(self):
+        """
+        Filtering with a modifier function must work correctly if the modifier
+        omits some reads and changes the ids of others.
+        """
+        def modifier(read):
+            if read.id == 'id1':
+                read.id = 'xxx'
+                return read
+
+        reads = Reads()
+        read1 = Read('id1', 'ATCG')
+        read2 = Read('id2', 'ATCG')
+        reads.add(read1)
+        reads.add(read2)
+        result = reads.filter(modifier=modifier)
+        self.assertEqual([Read('xxx', 'ATCG')], list(result))
+
 
 class TestSummarizePosition(TestCase):
     """


### PR DESCRIPTION
I did this in a more general way than the ticket describes. It allows the passing of a function that can return an entirely different read, a modified read, or `None` if the read it was passed should be skipped.

Fixes #347.
