### PR TITLE
Made all tests run (or skip) under pypy

### DIFF
--- a/dark/database.py
+++ b/dark/database.py
@@ -1,4 +1,18 @@
-from mysql import connector
+try:
+    from mysql import connector
+except ImportError:
+    import platform
+    if platform.python_implementation() == 'PyPy':
+        # PyPy doesn't have a version of mysql connector. Make a fake
+        # connector class that raises if used. This allows us to use other
+        # 'dark' code that happens to import dark.database but not use it.
+        class connector(object):
+            @staticmethod
+            def connect(**kwargs):
+                raise NotImplementedError(
+                    'The mysql connector class is not available in PyPy')
+    else:
+        raise
 
 from os import environ
 

--- a/dark/database.py
+++ b/dark/database.py
@@ -1,20 +1,6 @@
-try:
-    from mysql import connector
-except ImportError:
-    import platform
-    if platform.python_implementation() == 'PyPy':
-        # PyPy doesn't have a version of mysql connector. Make a fake
-        # connector class that raises if used. This allows us to use other
-        # 'dark' code that happens to import dark.database but not use it.
-        class connector(object):
-            @staticmethod
-            def connect(**kwargs):
-                raise NotImplementedError(
-                    'The mysql connector class is not available in PyPy')
-    else:
-        raise
-
 from os import environ
+
+from mysql import connector
 
 
 def getDatabaseConnection():

--- a/dark/features.py
+++ b/dark/features.py
@@ -1,5 +1,20 @@
 import numpy as np
-import matplotlib.pyplot as plt
+
+try:
+    from matplotlib import pyplot as plt
+except ImportError:
+    import platform
+    if platform.python_implementation() == 'PyPy':
+        # PyPy doesn't have a version of matplotlib. Make fake classes and
+        # a Line2D function and that raise if used. This allows us to use
+        # other 'dark' code that happens to import dark.mutations but not
+        # use the functions that rely on matplotlib.
+        class plt(object):
+            def __getattr__(self, _):
+                raise NotImplementedError(
+                    'matplotlib is not supported under pypy')
+    else:
+        raise
 
 from dark.entrez import getSequence
 

--- a/dark/graphics.py
+++ b/dark/graphics.py
@@ -4,9 +4,31 @@ from stat import S_ISDIR
 from math import ceil
 from collections import defaultdict
 from time import ctime, time
-import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
-from matplotlib import gridspec, patches
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import platform
+    if platform.python_implementation() == 'PyPy':
+        # PyPy doesn't have a version of matplotlib. Make fake classes and
+        # a Line2D function and that raise if used. This allows us to use
+        # other 'dark' code that happens to import dark.mutations but not
+        # use the functions that rely on matplotlib.
+        class plt(object):
+            def __getattr__(self, _):
+                raise NotImplementedError(
+                    'matplotlib is not supported under pypy')
+
+        gridspec = patches = plt
+
+        def Line2D(*args, **kwargs):
+            raise NotImplementedError('matplotlib is not supported under pypy')
+    else:
+        raise
+else:
+    from matplotlib.lines import Line2D
+    from matplotlib import gridspec, patches
+
 import numpy as np
 
 from dark.aa import propertiesForSequence, clustersForSequence

--- a/dark/mutations.py
+++ b/dark/mutations.py
@@ -1,6 +1,22 @@
 from collections import defaultdict
 import numpy as np
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import platform
+    if platform.python_implementation() == 'PyPy':
+        # PyPy doesn't have a version of matplotlib. Make a fake
+        # class that raises if it is used. This allows us to use other
+        # 'dark' code that happens to import dark.mutations but not use the
+        # functions that rely on matplotlib.
+        class plt(object):
+            def __getattr__(self, _):
+                raise NotImplementedError(
+                    'matplotlib is not supported under pypy')
+    else:
+        raise
+
 from random import choice, uniform
 
 from dark import ncbidb

--- a/requirements-pypy.txt
+++ b/requirements-pypy.txt
@@ -17,9 +17,20 @@ simplejson==3.5.3
 tornado==4.0.1
 MySQL-python==1.2.5
 Twisted==15.5.0
-# mysql-connector-python doesn't seem to install under pypy, though
-# at one point I'm pretty sure I (Terry) had it installed.
+#
+# This used to work, but now (2016-03-18) does not:
 # --allow-external mysql-connector-python
-# mysql-connector-python==2.0.4
+# mysql-connector-python==2.0.3
+#
+# Instead visit http://dev.mysql.com/downloads/connector/python/ and
+# download the source code of Connector/Python. I (Terry) am using version
+# 2.1.3 which can be obtained directly from
+# http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3.tar.gz
+#
+# Then (assuming you get version 2.1.3):
+#
+#   tar xz mysql-connector-python-2.1.3.tar.gz
+#   cd mysql-connector-python-2.1.3
+#   python setup.py install
 #
 # matplotlib is no longer building for me either. Sigh.

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -1,6 +1,23 @@
-import matplotlib.pyplot as plt
 import numpy as np
-from unittest import TestCase
+from unittest import TestCase, skipUnless
+
+try:
+    from matplotlib import pyplot as plt
+except ImportError:
+    import platform
+    if platform.python_implementation() == 'PyPy':
+        havePlt = False
+        # PyPy doesn't have a version of matplotlib. Make a fake class that
+        # raises if used.
+
+        class plt(object):
+            def __getattr__(self, _):
+                raise NotImplementedError(
+                    'matplotlib is not supported under pypy')
+    else:
+        raise
+else:
+    havePlt = True
 
 try:
     from unittest.mock import call, MagicMock, ANY
@@ -123,6 +140,9 @@ class Test_Feature(TestCase):
                          feature.legendLabel())
 
 
+# We can't test anything that uses a FeatureList under pypy because
+# dark.features makes use of matplotlib.
+@skipUnless(havePlt, 'matplotlib not supported under pypy')
 class Test_FeatureList(TestCase):
     """
     Tests of the C{FeatureList} class.
@@ -267,6 +287,7 @@ class Test_FeatureList(TestCase):
         self.assertEqual(1, len(featureList))
         self.assertTrue(featureList[0].subfeature)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testColors(self):
         """
         If the sequence fetcher returns a record with 3 features, each
@@ -300,6 +321,7 @@ class Test_FeatureAdder(TestCase):
         featureAdder = _FeatureAdder()
         self.assertFalse(featureAdder.tooManyFeaturesToPlot)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testTitle(self):
         """
         A L{_FeatureAdder} must set the title of its figure.
@@ -312,6 +334,7 @@ class Test_FeatureAdder(TestCase):
         fig.set_title.assert_called_with('Target sequence features',
                                          fontsize=16)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testYTicks(self):
         """
         A L{_FeatureAdder} must set the title of its figure.
@@ -323,6 +346,7 @@ class Test_FeatureAdder(TestCase):
         featureAdder.add(fig, 'title', 0, 100, sequenceFetcher=fetcher)
         fig.set_yticks.assert_called_with([])
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testOffline(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns C{None},
@@ -340,6 +364,7 @@ class Test_FeatureAdder(TestCase):
                                     fontsize=20)
         fig.axis.assert_called_with([0, 300, -1, 1])
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testNoFeatures(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns no features
@@ -362,6 +387,7 @@ class Test_FeatureAdder(TestCase):
         fig.axis.assert_called_with([0, 300, -1, 1])
         self.assertEqual([], result)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testOneFeatureRaisesNotImplementedError(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,
@@ -382,6 +408,7 @@ class Test_FeatureAdder(TestCase):
         self.assertRaises(NotImplementedError, featureAdder.add, fig, 'title',
                           0, 300, sequenceFetcher=fetcher)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testTooManyFeatures(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns too many
@@ -416,6 +443,7 @@ class TestProteinFeatureAdder(TestCase):
     Tests of the C{ProteinFeatureAdder} class.
     """
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testUnwantedFeature(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature
@@ -436,6 +464,7 @@ class TestProteinFeatureAdder(TestCase):
         self.assertEqual([], fig.plot.call_args_list)
         self.assertEqual([], result)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testOneFeature(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,
@@ -472,6 +501,7 @@ class TestNucleotideFeatureAdder(TestCase):
     Tests of the C{NucleotideFeatureAdder} class.
     """
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testUnwantedFeature(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature
@@ -492,6 +522,7 @@ class TestNucleotideFeatureAdder(TestCase):
         self.assertEqual([], fig.plot.call_args_list)
         self.assertEqual([], result)
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testOneFeature(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,
@@ -523,6 +554,7 @@ class TestNucleotideFeatureAdder(TestCase):
         self.assertTrue(isinstance(result, FeatureList))
         self.assertEqual(1, len(result))
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testOneFeatureAdjusted(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,
@@ -558,6 +590,7 @@ class TestNucleotideFeatureAdder(TestCase):
         self.assertTrue(isinstance(result, FeatureList))
         self.assertEqual(1, len(result))
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testSubfeaturesAreMovedDown(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,
@@ -594,6 +627,7 @@ class TestNucleotideFeatureAdder(TestCase):
         self.assertTrue(isinstance(result, FeatureList))
         self.assertEqual(2, len(result))
 
+    @skipUnless(havePlt, 'matplotlib not supported under pypy')
     def testPolyproteinsAreMovedUp(self):
         """
         If the sequence fetcher used by a L{_FeatureAdder} returns a feature,


### PR DESCRIPTION
The taxonomy code can now be imported but will raise `NotImplementedError` if any attempt is made to use it.

Fixes #384.