### PR TITLE
Made it possible to save SSAAReads as plain FASTA

### DIFF
--- a/dark/reads.py
+++ b/dark/reads.py
@@ -425,26 +425,30 @@ class SSAARead(AARead):
         structure = None if self.structure is None else self.structure[item]
         return self.__class__(self.id, sequence, structure)
 
-    def toString(self, format_='fasta', structureSuffix=':structure'):
+    def toString(self, format_='fasta-ss', structureSuffix=':structure'):
         """
         Convert the read to a string in PDB format (sequence & structure). This
         consists of two FASTA records, one for the sequence then one for the
         structure.
 
-        @param format_: Must be 'fasta'. This argument is required for
-            compatibility with C{dark.reads.Reads.save}.
+        @param format_: Either 'fasta-ss' or 'fasta'. In the former case, the
+            structure information is returned. Otherwise, plain FASTA is
+            returned.
         @param structureSuffix: The C{str} suffix to append to the read id
             for the second FASTA record, containing the structure information.
         @raise ValueError: If C{format_} is not 'fasta'.
         @return: A C{str} representing the read sequence and structure in PDB
             FASTA format.
         """
-        if format_ == 'fasta':
+        if format_ == 'fasta-ss':
             return '>%s\n%s\n>%s%s\n%s\n' % (
                 self.id, self.sequence, self.id, structureSuffix,
                 self.structure)
         else:
-            raise ValueError("Format must be 'fasta'.")
+            if six.PY3:
+                return super().toString(format_=format_)
+            else:
+                return AARead.toString(self, format_=format_)
 
 
 class SSAAReadWithX(SSAARead):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.27',
+      version='1.0.28',
       packages=['dark'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -1432,6 +1432,62 @@ class _TestSSAAReadMixin(object):
         self.assertEqual(self.CLASS('id', 'FRML', 'HESB'),
                          self.CLASS('id', 'LMRF', 'BSEH')[::-1])
 
+    def testToString(self):
+        """
+        toString must return the expected 2 FASTA records (one of which is
+        the structure information).
+        """
+        self.assertEqual(
+            '>id-1234\n'
+            'FFMM\n'
+            '>id-1234:structure\n'
+            'HHHH\n',
+            self.CLASS('id-1234', 'FFMM', 'HHHH').toString())
+
+    def testToStringWithStructureSuffix(self):
+        """
+        toString must return the expected 2 FASTA records when given a
+        specific structure id suffix.
+        """
+        self.assertEqual(
+            '>id-12\n'
+            'FFMM\n'
+            '>id-12:x\n'
+            'HHHH\n',
+            self.CLASS('id-12', 'FFMM', 'HHHH').toString(structureSuffix=':x'))
+
+    def testToStringWithExplicitFastaSSFormat(self):
+        """
+        toString must return the expected 2 FASTA records when 'fasta-ss' is
+        passed as the C{format_} argument.
+        """
+        self.assertEqual(
+            '>id-1234\n'
+            'FFMM\n'
+            '>id-1234:structure\n'
+            'HHHH\n',
+            self.CLASS('id-1234', 'FFMM', 'HHHH').toString(format_='fasta-ss'))
+
+    def testToStringWithExplicitFastaFormat(self):
+        """
+        toString must return normal FASTA when 'fasta' is passed as the
+        C{format_} argument.
+        """
+        self.assertEqual(
+            '>id-1234\n'
+            'FFMM\n',
+            self.CLASS('id-1234', 'FFMM', 'HHHH').toString(format_='fasta'))
+
+    def testToStringWithUnknownFormat(self):
+        """
+        toString must raise ValueError when something other than 'fasta' or
+        'fasta-ss' is passed as the C{format_} argument.
+        """
+        read = self.CLASS('id-1234', 'FFMM', 'HHHH')
+        error = "^Format must be either 'fasta' or 'fastq'\."
+        six.assertRaisesRegex(
+            self, ValueError, error, read.toString, format_='pasta')
+
 
 class TestSSAARead(TestCase, _TestSSAAReadMixin):
     """
@@ -1451,51 +1507,6 @@ class TestSSAAReadWithX(TestCase, _TestSSAAReadMixin):
         An SSAAReadWithX must be able to contain an 'X' character.
         """
         self.assertEqual('AFGX', SSAAReadWithX('id', 'AFGX', 'HHHH').sequence)
-
-    def testToString(self):
-        """
-        toString must return the expected 2 FASTA records.
-        """
-        self.assertEqual(
-            '>id-1234\n'
-            'FFMM\n'
-            '>id-1234:structure\n'
-            'HHHH\n',
-            SSAARead('id-1234', 'FFMM', 'HHHH').toString())
-
-    def testToStringWithStructureSuffix(self):
-        """
-        toString must return the expected 2 FASTA records when given a
-        specific structure id suffix.
-        """
-        self.assertEqual(
-            '>id-12\n'
-            'FFMM\n'
-            '>id-12:x\n'
-            'HHHH\n',
-            SSAARead('id-12', 'FFMM', 'HHHH').toString(structureSuffix=':x'))
-
-    def testToStringWithExplicitFastaFormat(self):
-        """
-        toString must return the expected 2 FASTA records when 'fasta' is
-        passed as the C{format_} argument.
-        """
-        self.assertEqual(
-            '>id-1234\n'
-            'FFMM\n'
-            '>id-1234:structure\n'
-            'HHHH\n',
-            SSAARead('id-1234', 'FFMM', 'HHHH').toString(format_='fasta'))
-
-    def testToStringWithNonFastaFormat(self):
-        """
-        toString must raise ValueError when something other than 'fasta' is
-        passed as the C{format_} argument.
-        """
-        read = SSAARead('id-1234', 'FFMM', 'HHHH')
-        error = "^Format must be 'fasta'\."
-        six.assertRaisesRegex(
-            self, ValueError, error, read.toString, format_='pasta')
 
 
 class TestTranslatedRead(TestCase):


### PR DESCRIPTION
Also, changed ss-fasta to fasta-ss to be more like fastq.

Fixes #394.