### PR TITLE
Make it so checkAlphabet can be passed to noninteractive-alignment-panel.py

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     # Args for the JSON BLAST and FASTA files.
     parser.add_argument(
-        'json', metavar='BLAST-JSON-file', type=str, nargs='+',
+        '--json', metavar='BLAST-JSON-file', type=str, nargs='+',
         help='the JSON file of BLAST output.')
 
     parser.add_argument(
@@ -186,8 +186,16 @@ if __name__ == '__main__':
         '--logBase', type=float, default=DEFAULT_LOG_LINEAR_X_AXIS_BASE,
         help='The base of the logarithm to use if logLinearXAxis is True')
 
+    parser.add_argument(
+        '--checkAlphabet', type=int, default=None,
+        help=('An integer, indicating how many bases or amino acids at the '
+              'start of sequences should have their alphabet checked. If not '
+              'specified, all bases are checked.'))
+
     args = parser.parse_args()
-    readsAlignments = BlastReadsAlignments(FastaReads(args.fasta), args.json)
+    readsAlignments = BlastReadsAlignments(
+        FastaReads(args.fasta, checkAlphabet=args.checkAlphabet),
+        args.json)
 
     readsAlignments.filter(
         minSequenceLen=args.minSequenceLen,

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -440,7 +440,7 @@ class AAReadORF(AARead):
         if six.PY3:
             result = super().toDict()
         else:
-            result = AARead.toDict()
+            result = AARead.toDict(self)
 
         result.update({
             'start': self.start,
@@ -610,7 +610,7 @@ class TranslatedRead(AARead):
         if six.PY3:
             result = super().toDict()
         else:
-            result = AARead.toDict()
+            result = AARead.toDict(self)
 
         result.update({
             'frame': self.frame,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.34',
+      version='1.0.36',
       packages=['dark', 'dark.blast'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
Also, fixed two tests that were failing under Python 2.

Fixes #410.
