### PR TITLE
Noninteractive alignment panel earlier import

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -14,15 +14,15 @@ import sys
 import argparse
 from collections import defaultdict
 
-from dark.fasta import FastaReads
-from dark.blast.alignments import BlastReadsAlignments
-from dark.titles import TitlesAlignments
-from dark.graphics import DEFAULT_LOG_LINEAR_X_AXIS_BASE, alignmentPanel
-
 # It's not clear that the PDF backend is the right choice here, but it
 # works (i.e., the generation of PNG images works fine).
 import matplotlib
 matplotlib.use('PDF')
+
+from dark.fasta import FastaReads
+from dark.blast.alignments import BlastReadsAlignments
+from dark.titles import TitlesAlignments
+from dark.graphics import DEFAULT_LOG_LINEAR_X_AXIS_BASE, alignmentPanel
 
 
 def parseColors(colors):

--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -227,6 +227,10 @@ if __name__ == '__main__':
     print('Found %d interesting title%s.' % (nTitles,
                                              '' if nTitles == 1 else 's'))
 
+    if nTitles == 0:
+        print('No alignment panel generated due to no matching titles.')
+        sys.exit(0)
+
     if args.earlyExit:
         print('Matched titles (sorted by best score, descending):')
         print('\n'.join(titlesAlignments.sortTitles('maxScore')))

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.37',
+      version='1.0.39',
       packages=['dark', 'dark.blast'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
matplotlib needed to be imported earlier and set to use a non-interactive backend. Also, exit early if no titles are matched to avoid a later error due to having nothing to display.

Fixes #416.
