### PR TITLE
Fasta files multiple filenames

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -64,11 +64,11 @@ if __name__ == '__main__':
     # Args for the JSON BLAST and FASTA files.
     parser.add_argument(
         '--json', metavar='BLAST-JSON-file', nargs='+',
-        help='the JSON file of BLAST output.')
+        help='the JSON file(s) of BLAST output.')
 
     parser.add_argument(
-        '--fasta', metavar='FASTA-file', required=True,
-        help='the FASTA file of sequences that were given to BLAST.')
+        '--fasta', metavar='FASTA-file', nargs='+',
+        help='the FASTA file(s) of sequences that were given to BLAST.')
 
     # Args for filtering on ReadsAlignments.
     parser.add_argument(

--- a/dark/fasta.py
+++ b/dark/fasta.py
@@ -83,8 +83,8 @@ class FastaReads(Reads):
     Subclass of L{dark.reads.Reads} providing access to FASTA reads.
 
     @param _files: Either a single C{str} file name or file handle, or a
-        C{list} of (possibly mixed) C{str} file names or file handles. Each
-        file / file handle must contain sequences in FASTA format.
+        C{list} of C{str} file names and/or file handles. Each file or file
+        handle must contain sequences in FASTA format.
     @param readClass: The class of read that should be yielded by iter.
     @param checkAlphabet: An C{int} or C{None}. If C{None}, alphabet checking
         will be done on all reads. If an C{int}, only that many reads will be

--- a/dark/fasta.py
+++ b/dark/fasta.py
@@ -94,7 +94,7 @@ class FastaReads(Reads):
     """
     def __init__(self, _files, readClass=DNARead, checkAlphabet=None,
                  upperCase=False):
-        self._files = [_files] if isinstance(_files, string_types) else _files
+        self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
         self._checkAlphabet = checkAlphabet
         # TODO: It would be better if upperCase were an argument that could

--- a/dark/fasta.py
+++ b/dark/fasta.py
@@ -1,4 +1,4 @@
-from six import PY3, string_types
+from six import PY3
 from hashlib import md5
 
 from Bio import SeqIO

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -24,8 +24,8 @@ class SSFastaReads(Reads):
     alignment with the sequence.
 
     @param _files: Either a single C{str} file name or file handle, or a
-        C{list} of (possibly mixed) C{str} file names or file handles. Each
-        file / file handle must contain sequences in FASTA format.
+        C{list} of C{str} file names and/or file handles. Each file or file
+        handle must contain sequences in PDB FASTA format (see above).
     @param readClass: The class of read that should be yielded by iter. This
         must accept 3 C{str} arguments: an id, the sequence, the structure.
     @param checkAlphabet: An C{int} or C{None}. If C{None}, alphabet checking

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -36,7 +36,7 @@ class SSFastaReads(Reads):
     """
     def __init__(self, _files, readClass=SSAARead, checkAlphabet=None,
                  upperCase=False):
-        self._files = [_files] if isinstance(_files, string_types) else _files
+        self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
         self._checkAlphabet = checkAlphabet
         self._upperCase = upperCase

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -1,4 +1,4 @@
-from six import PY3, string_types
+from six import PY3
 from Bio import SeqIO
 
 from dark.reads import Reads, SSAARead

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -1,7 +1,8 @@
-import six
+from six import PY3, string_types
 from Bio import SeqIO
 
 from dark.reads import Reads, SSAARead
+from dark.utils import asHandle
 
 
 class SSFastaReads(Reads):
@@ -22,8 +23,9 @@ class SSFastaReads(Reads):
     '-', to make sure the structure information has the correct length and
     alignment with the sequence.
 
-    @param _file: A C{str} file name or file handle, containing
-        sequences and structures in FASTA format,
+    @param _files: Either a single C{str} file name or file handle, or a
+        C{list} of (possibly mixed) C{str} file names or file handles. Each
+        file / file handle must contain sequences in FASTA format.
     @param readClass: The class of read that should be yielded by iter. This
         must accept 3 C{str} arguments: an id, the sequence, the structure.
     @param checkAlphabet: An C{int} or C{None}. If C{None}, alphabet checking
@@ -32,13 +34,13 @@ class SSFastaReads(Reads):
     @param upperCase: If C{True}, both read and structure sequences will be
         converted to upper case.
     """
-    def __init__(self, _file, readClass=SSAARead, checkAlphabet=None,
+    def __init__(self, _files, readClass=SSAARead, checkAlphabet=None,
                  upperCase=False):
-        self._file = _file
+        self._files = [_files] if isinstance(_files, string_types) else _files
         self._readClass = readClass
         self._checkAlphabet = checkAlphabet
         self._upperCase = upperCase
-        if six.PY3:
+        if PY3:
             super().__init__()
         else:
             Reads.__init__(self)
@@ -55,39 +57,42 @@ class SSFastaReads(Reads):
         checkAlphabet = self._checkAlphabet
         upperCase = self._upperCase
         count = 0
-        records = SeqIO.parse(self._file, 'fasta')
-        while True:
-            try:
-                record = next(records)
-            except StopIteration:
-                break
+        for _file in self._files:
+            with asHandle(_file) as fp:
+                records = SeqIO.parse(fp, 'fasta')
+                while True:
+                    try:
+                        record = next(records)
+                    except StopIteration:
+                        break
 
-            count += 1
+                    count += 1
 
-            try:
-                structureRecord = next(records)
-            except StopIteration:
-                raise ValueError('Structure file %r has an odd number of '
-                                 'records.' % self._file)
+                    try:
+                        structureRecord = next(records)
+                    except StopIteration:
+                        raise ValueError('Structure file %r has an odd number '
+                                         'of records.' % _file)
 
-            if len(structureRecord) != len(record):
-                raise ValueError(
-                    'Sequence %r length (%d) is not equal to structure %r '
-                    'length (%d) in input file %r.' % (
-                        record.description, len(record),
-                        structureRecord.description, len(structureRecord),
-                        self._file))
+                    if len(structureRecord) != len(record):
+                        raise ValueError(
+                            'Sequence %r length (%d) is not equal to '
+                            'structure %r length (%d) in input file %r.' % (
+                                record.description, len(record),
+                                structureRecord.description,
+                                len(structureRecord), _file))
 
-            if upperCase:
-                read = self._readClass(record.description,
-                                       str(record.seq.upper()),
-                                       str(structureRecord.seq.upper()))
-            else:
-                read = self._readClass(record.description,
-                                       str(record.seq),
-                                       str(structureRecord.seq))
+                    if upperCase:
+                        read = self._readClass(
+                            record.description,
+                            str(record.seq.upper()),
+                            str(structureRecord.seq.upper()))
+                    else:
+                        read = self._readClass(record.description,
+                                               str(record.seq),
+                                               str(structureRecord.seq))
 
-            if checkAlphabet is None or count < checkAlphabet:
-                read.checkAlphabet(count=None)
+                    if checkAlphabet is None or count < checkAlphabet:
+                        read.checkAlphabet(count=None)
 
-            yield read
+                    yield read

--- a/dark/fastq.py
+++ b/dark/fastq.py
@@ -1,4 +1,4 @@
-from six import PY3, string_types
+from six import PY3
 
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 

--- a/dark/fastq.py
+++ b/dark/fastq.py
@@ -16,7 +16,7 @@ class FastqReads(Reads):
     @param readClass: The class of read that should be yielded by iter.
     """
     def __init__(self, _files, readClass=DNARead):
-        self._files = [_files] if isinstance(_files, string_types) else _files
+        self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self.readClass = readClass
         if PY3:
             super().__init__()

--- a/dark/fastq.py
+++ b/dark/fastq.py
@@ -11,8 +11,8 @@ class FastqReads(Reads):
     Subclass of L{dark.reads.Reads} providing access to FASTQ reads.
 
     @param _files: Either a single C{str} file name or file handle, or a
-        C{list} of (possibly mixed) C{str} file names or file handles. Each
-        file / file handle must contain sequences in FASTQ format.
+        C{list} of C{str} file names and/or file handles. Each file or file
+        handle must contain sequences in FASTQ format.
     @param readClass: The class of read that should be yielded by iter.
     """
     def __init__(self, _files, readClass=DNARead):

--- a/dark/fastq.py
+++ b/dark/fastq.py
@@ -1,36 +1,38 @@
-import six
+from six import PY3, string_types
 
-from Bio.File import as_handle
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 from dark.reads import Reads, DNARead
+from dark.utils import asHandle
 
 
 class FastqReads(Reads):
     """
     Subclass of L{dark.reads.Reads} providing access to FASTQ reads.
 
-    @param file_: A C{str} file name or file handle, containing
-        sequences in FASTQ format,
+    @param _files: Either a single C{str} file name or file handle, or a
+        C{list} of (possibly mixed) C{str} file names or file handles. Each
+        file / file handle must contain sequences in FASTQ format.
     @param readClass: The class of read that should be yielded by iter.
     """
-    def __init__(self, file_, readClass=DNARead):
-        self.file_ = file_
+    def __init__(self, _files, readClass=DNARead):
+        self._files = [_files] if isinstance(_files, string_types) else _files
         self.readClass = readClass
-        if six.PY3:
+        if PY3:
             super().__init__()
         else:
             Reads.__init__(self)
 
     def iter(self):
         """
-        Iterate over the sequences in self.file_, yielding each as an
-        instance of the desired read class.
+        Iterate over the sequences in the files in self.files_, yielding each
+        as an instance of the desired read class.
         """
-        # Use FastqGeneralIterator because it provides access to the
-        # unconverted quality string (i.e., it doesn't try to figure out
-        # the numeric quality values, which we don't care about at this
-        # point).
-        with as_handle(self.file_) as fp:
-            for sequenceId, sequence, quality in FastqGeneralIterator(fp):
-                yield self.readClass(sequenceId, sequence, quality)
+        for _file in self._files:
+            with asHandle(_file) as fp:
+                # Use FastqGeneralIterator because it provides access to
+                # the unconverted quality string (i.e., it doesn't try to
+                # figure out the numeric quality values, which we don't
+                # care about at this point).
+                for sequenceId, sequence, quality in FastqGeneralIterator(fp):
+                    yield self.readClass(sequenceId, sequence, quality)

--- a/dark/utils.py
+++ b/dark/utils.py
@@ -1,7 +1,11 @@
 from __future__ import division
 
 import string
+import six
+import bz2
+import gzip
 from os.path import basename
+from contextlib import contextmanager
 
 
 def numericallySortFilenames(names):
@@ -95,3 +99,25 @@ def median(l):
         raise ValueError('arg is an empty sequence')
     else:
         return _median(l)
+
+
+@contextmanager
+def asHandle(handleish, mode='r'):
+    """
+    Decorator for file opening that makes it easy to open compressed files.
+    Based on L{Bio.File.as_handle}.
+
+    @param handleish: Either a C{str} or a file handle.
+    @return: A generator that can be turned into a context manager via
+        L{contextlib.contextmanager}.
+    """
+    if isinstance(handleish, six.string_types):
+        if handleish.endswith('.gz'):
+            yield gzip.GzipFile(handleish)
+        elif handleish.endswith('.bz2'):
+            yield bz2.BZ2File(handleish)
+        else:
+            with open(handleish) as fp:
+                yield fp
+    else:
+        yield handleish

--- a/dark/utils.py
+++ b/dark/utils.py
@@ -102,22 +102,22 @@ def median(l):
 
 
 @contextmanager
-def asHandle(handleish, mode='r'):
+def asHandle(fileNameOrHandle, mode='r'):
     """
     Decorator for file opening that makes it easy to open compressed files.
     Based on L{Bio.File.as_handle}.
 
-    @param handleish: Either a C{str} or a file handle.
+    @param fileNameOrHandle: Either a C{str} or a file handle.
     @return: A generator that can be turned into a context manager via
         L{contextlib.contextmanager}.
     """
-    if isinstance(handleish, six.string_types):
-        if handleish.endswith('.gz'):
-            yield gzip.GzipFile(handleish)
-        elif handleish.endswith('.bz2'):
-            yield bz2.BZ2File(handleish)
+    if isinstance(fileNameOrHandle, six.string_types):
+        if fileNameOrHandle.endswith('.gz'):
+            yield gzip.GzipFile(fileNameOrHandle)
+        elif fileNameOrHandle.endswith('.bz2'):
+            yield bz2.BZ2File(fileNameOrHandle)
         else:
-            with open(handleish) as fp:
+            with open(fileNameOrHandle) as fp:
                 yield fp
     else:
-        yield handleish
+        yield fileNameOrHandle

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.40',
+      version='1.0.41',
       packages=['dark', 'dark.blast'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_fasta_ss.py
+++ b/test/test_fasta_ss.py
@@ -1,6 +1,6 @@
 import six
+import bz2
 from six.moves import builtins
-from six import StringIO
 from unittest import TestCase
 
 try:
@@ -14,6 +14,27 @@ from dark.reads import SSAARead
 from dark.fasta_ss import SSFastaReads
 
 
+class BZ2(object):
+    """
+    A BZ2File mock.
+    """
+    def __init__(self, data):
+        self._data = data
+        self._index = 0
+
+    def readline(self):
+        self._index += 1
+        try:
+            return self._data[self._index - 1]
+        except IndexError:
+            return None
+
+    def __iter__(self):
+        index = self._index
+        self._index = len(self._data)
+        return iter(self._data[index:])
+
+
 class TestSSFastaReads(TestCase):
     """
     Tests for the L{dark.fasta.SSFastaReads} class.
@@ -23,9 +44,11 @@ class TestSSFastaReads(TestCase):
         """
         An empty PDB FASTA file results in an empty iterator.
         """
-        data = StringIO()
-        reads = SSFastaReads(data)
-        self.assertEqual([], list(reads))
+        data = ''
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = SSFastaReads(data)
+            self.assertEqual([], list(reads))
 
     def testOddNumberOfRecords(self):
         """
@@ -58,39 +81,47 @@ class TestSSFastaReads(TestCase):
         """
         A PDB FASTA file with one read must be read properly.
         """
-        data = StringIO('\n'.join(['>seq1', 'REDD', '>str1', 'HH--']))
-        reads = list(SSFastaReads(data))
-        self.assertEqual([SSAARead('seq1', 'REDD', 'HH--')], reads)
+        data = '\n'.join(['>seq1', 'REDD', '>str1', 'HH--'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data))
+            self.assertEqual([SSAARead('seq1', 'REDD', 'HH--')], reads)
 
     def testNoQuality(self):
         """
         A PDB FASTA file read must not have any quality information.
         """
-        data = StringIO('\n'.join(['>seq1', 'REDD', '>str1', 'HH--']))
-        reads = list(SSFastaReads(data))
-        self.assertIs(None, reads[0].quality)
+        data = '\n'.join(['>seq1', 'REDD', '>str1', 'HH--'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data))
+            self.assertIs(None, reads[0].quality)
 
     def testTwoReads(self):
         """
         A PDB FASTA file with two reads must be read properly and its
         sequences must be returned in the correct order.
         """
-        data = StringIO('\n'.join(['>seq1', 'REDD', '>str1', 'HH--',
-                                   '>seq2', 'REAA', '>str2', 'HHEE']))
-        reads = list(SSFastaReads(data))
-        self.assertEqual(2, len(reads))
-        self.assertEqual([SSAARead('seq1', 'REDD', 'HH--'),
-                          SSAARead('seq2', 'REAA', 'HHEE')],
-                         reads)
+        data = '\n'.join(['>seq1', 'REDD', '>str1', 'HH--',
+                          '>seq2', 'REAA', '>str2', 'HHEE'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data))
+            self.assertEqual(2, len(reads))
+            self.assertEqual([SSAARead('seq1', 'REDD', 'HH--'),
+                              SSAARead('seq2', 'REAA', 'HHEE')],
+                             reads)
 
     def testTypeDefaultsToSSAARead(self):
         """
         A PDB FASTA file whose type is not specified must result in reads that
         are instances of SSAARead.
         """
-        data = StringIO('\n'.join(['>seq1', 'REDD', '>str1', 'HH--']))
-        reads = list(SSFastaReads(data))
-        self.assertTrue(isinstance(reads[0], SSAARead))
+        data = '\n'.join(['>seq1', 'REDD', '>str1', 'HH--'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data))
+            self.assertTrue(isinstance(reads[0], SSAARead))
 
     def testReadClass(self):
         """
@@ -101,9 +132,12 @@ class TestSSFastaReads(TestCase):
             def __init__(self, id, sequence, structure):
                 pass
 
-        data = StringIO('\n'.join(['>seq1', 'RRRR', '>str1', 'HHHH']))
-        reads = list(SSFastaReads(data, readClass=ReadClass, checkAlphabet=0))
-        self.assertTrue(isinstance(reads[0], ReadClass))
+        data = '\n'.join(['>seq1', 'RRRR', '>str1', 'HHHH'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data, readClass=ReadClass,
+                                      checkAlphabet=0))
+            self.assertTrue(isinstance(reads[0], ReadClass))
 
     def testAlphabetIsCheckedAndRaisesValueErrorOnFirstRead(self):
         """
@@ -111,12 +145,14 @@ class TestSSFastaReads(TestCase):
         its sequences have the correct alphabet and to raise ValueError if not.
         A non-alphabetic character in the first read must be detected.
         """
-        data = StringIO('\n'.join(['>seq1', 'at-at', '>str1', 'HH-HH']))
+        data = '\n'.join(['>seq1', 'at-at', '>str1', 'HH-HH'])
         error = ("^Read alphabet \('-AT'\) is not a subset of expected "
                  "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
                  "SSAARead\.$")
-        six.assertRaisesRegex(self, ValueError, error, list,
-                              SSFastaReads(data))
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            six.assertRaisesRegex(self, ValueError, error, list,
+                                  SSFastaReads(data))
 
     def testAlphabetIsCheckedAndRaisesValueErrorOnSecondRead(self):
         """
@@ -124,21 +160,25 @@ class TestSSFastaReads(TestCase):
         its sequences have the correct alphabet and to raise ValueError if not.
         A non-alphabetic character in the second read must be detected.
         """
-        data = StringIO('\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
-                                   '>seq2', 'a-at', '>str2', 'hhhh']))
+        data = '\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
+                          '>seq2', 'a-at', '>str2', 'hhhh'])
         error = ("^Read alphabet \('-AT'\) is not a subset of expected "
                  "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
                  "SSAARead\.$")
-        six.assertRaisesRegex(self, ValueError, error, list,
-                              SSFastaReads(data))
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            six.assertRaisesRegex(self, ValueError, error, list,
+                                  SSFastaReads(data))
 
     def testDisableAlphabetChecking(self):
         """
         It must be possible to have a SSFastaReads instance not do alphabet
         checking, if requested (by passing checkAlphabet=0).
         """
-        data = StringIO('\n'.join(['>seq1', 'rr-rr', '>str1', 'hh-hh']))
-        self.assertEqual(1, len(list(SSFastaReads(data, checkAlphabet=0))))
+        data = '\n'.join(['>seq1', 'rr-rr', '>str1', 'hh-hh'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            self.assertEqual(1, len(list(SSFastaReads(data, checkAlphabet=0))))
 
     def testOnlyCheckSomeAlphabets(self):
         """
@@ -146,26 +186,64 @@ class TestSSFastaReads(TestCase):
         reads checked. A non-alphabetic character in a later read must not
         stop that read from being processed.
         """
-        data = StringIO('\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
-                                   '>seq2', 'r-rr', '>str2', 'h-hh']))
-        reads = list(SSFastaReads(data, checkAlphabet=1))
-        self.assertEqual(2, len(reads))
-        self.assertEqual('r-rr', reads[1].sequence)
+        data = '\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
+                          '>seq2', 'r-rr', '>str2', 'h-hh'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data, checkAlphabet=1))
+            self.assertEqual(2, len(reads))
+            self.assertEqual('r-rr', reads[1].sequence)
 
     def testConvertLowerToUpperCaseIfSpecified(self):
         """
         A read sequence and structure must be converted from lower to upper
         case if requested.
         """
-        data = StringIO('\n'.join(['>seq1', 'rrrff', '>str1', 'hheeh']))
-        reads = list(SSFastaReads(data, upperCase=True))
-        self.assertEqual([SSAARead('seq1', 'RRRFF', 'HHEEH')], reads)
+        data = '\n'.join(['>seq1', 'rrrff', '>str1', 'hheeh'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data, upperCase=True))
+            self.assertEqual([SSAARead('seq1', 'RRRFF', 'HHEEH')], reads)
 
     def testDontConvertLowerToUpperCaseIfNotSpecified(self):
         """
         A read sequence and its structure must not be converted from lower to
         upper case if the conversion is not requested.
         """
-        data = StringIO('\n'.join(['>seq1', 'rrFF', '>str1', 'HHee']))
-        reads = list(SSFastaReads(data))
-        self.assertEqual([SSAARead('seq1', 'rrFF', 'HHee')], reads)
+        data = '\n'.join(['>seq1', 'rrFF', '>str1', 'HHee'])
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = list(SSFastaReads(data))
+            self.assertEqual([SSAARead('seq1', 'rrFF', 'HHee')], reads)
+
+    def testTwoFiles(self):
+        """
+        It must be possible to read from two FASTA files.
+        """
+        class SideEffect(object):
+            def __init__(self, test):
+                self.test = test
+                self.count = 0
+
+            def sideEffect(self, filename):
+                if self.count == 0:
+                    self.test.assertEqual('file1.fasta.bz2', filename)
+                    self.count += 1
+                    return BZ2(['>id1\n', 'ACTG\n', '>id1\n', 'hhhh\n'])
+                elif self.count == 1:
+                    self.test.assertEqual('file2.fasta.bz2', filename)
+                    self.count += 1
+                    return BZ2(['>id2\n', 'CAGT\n', '>id2\n', 'eeee\n'])
+                else:
+                    self.fail('We are only supposed to be called twice!')
+
+        sideEffect = SideEffect(self)
+        with patch.object(bz2, 'BZ2File') as mockMethod:
+            mockMethod.side_effect = sideEffect.sideEffect
+            reads = SSFastaReads(['file1.fasta.bz2', 'file2.fasta.bz2'])
+            self.assertEqual(
+                [
+                    SSAARead('id1', 'ACTG', 'hhhh'),
+                    SSAARead('id2', 'CAGT', 'eeee'),
+                ],
+                list(reads))

--- a/test/test_fastq.py
+++ b/test/test_fastq.py
@@ -1,3 +1,5 @@
+import bz2
+
 from six.moves import builtins
 
 from dark.reads import AARead, DNARead, RNARead
@@ -11,6 +13,27 @@ except ImportError:
     from mock import patch
 
 from .mocking import mockOpen
+
+
+class BZ2(object):
+    """
+    A BZ2File mock.
+    """
+    def __init__(self, data):
+        self._data = data
+        self._index = 0
+
+    def readline(self):
+        self._index += 1
+        try:
+            return self._data[self._index - 1]
+        except IndexError:
+            return None
+
+    def __iter__(self):
+        index = self._index
+        self._index = len(self._data)
+        return iter(self._data[index:])
 
 
 class TestFastqReads(TestCase):
@@ -94,3 +117,35 @@ class TestFastqReads(TestCase):
         with patch.object(builtins, 'open', mockOpener):
             reads = list(FastqReads('filename.fastq', RNARead))
             self.assertTrue(isinstance(reads[0], RNARead))
+
+    def testTwoFiles(self):
+        """
+        It must be possible to read from two FASTQ files.
+        """
+        class SideEffect(object):
+            def __init__(self, test):
+                self.test = test
+                self.count = 0
+
+            def sideEffect(self, filename):
+                if self.count == 0:
+                    self.test.assertEqual('file1.fastq.bz2', filename)
+                    self.count += 1
+                    return BZ2(['@id1\n', 'ACTG\n', '+\n', '!!!!\n'])
+                elif self.count == 1:
+                    self.test.assertEqual('file2.fastq.bz2', filename)
+                    self.count += 1
+                    return BZ2(['@id2\n', 'CAGT\n', '+\n', '!!!!\n'])
+                else:
+                    self.fail('We are only supposed to be called twice!')
+
+        sideEffect = SideEffect(self)
+        with patch.object(bz2, 'BZ2File') as mockMethod:
+            mockMethod.side_effect = sideEffect.sideEffect
+            reads = FastqReads(['file1.fastq.bz2', 'file2.fastq.bz2'])
+            self.assertEqual(
+                [
+                    DNARead('id1', 'ACTG', '!!!!'),
+                    DNARead('id2', 'CAGT', '!!!!'),
+                ],
+                list(reads))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,30 @@
 import six
+import bz2
+import gzip
+from six.moves import builtins
 from unittest import TestCase
 
-from dark.utils import numericallySortFilenames, median
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from .mocking import mockOpen
+
+from dark.utils import numericallySortFilenames, median, asHandle
+
+
+class BZ2(object):
+    """
+    A BZ2File mock.
+    """
+    def __init__(self, data):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+GZIP = BZ2
 
 
 class TestNumericallySortFilenames(TestCase):
@@ -102,3 +125,60 @@ class TestMedian(TestCase):
         The median function must work on a list of length five.
         """
         self.assertEqual(5.9, median([3.1, 1.3, 7.6, 9.9, 5.9]))
+
+
+class TestAsHandle(TestCase):
+    """
+    Test the asHandle function
+    """
+
+    def testOpenFile(self):
+        """
+        When an open file pointer is passed to asHandle, that same file
+        pointer must be returned.
+        """
+        mockOpener = mockOpen()
+        with patch.object(builtins, 'open', mockOpener):
+            fp = open('file')
+            with asHandle(fp) as newfp:
+                self.assertIs(fp, newfp)
+
+    def testStr(self):
+        """
+        When a string filename is passed to asHandle, it must be possible to
+        read the correct data from the fp that is returned.
+        """
+        mockOpener = mockOpen(read_data='xxx')
+        with patch.object(builtins, 'open', mockOpener):
+            with asHandle('file') as fp:
+                self.assertEqual('xxx', fp.read())
+
+    def testBZ2(self):
+        """
+        When a string '*.bz2' filename is passed to asHandle, it must be
+        possible to read the correct data from the fp that is returned.
+        """
+        # This test should be better. It should actually create some bz2
+        # compressed data and make sure that it's decompressed
+        # properly. But Python mocking makes me so confused...
+        result = BZ2('xxx')
+
+        with patch.object(bz2, 'BZ2File') as mockMethod:
+            mockMethod.return_value = result
+            with asHandle('file.bz2') as fp:
+                self.assertEqual('xxx', fp.read())
+
+    def testGzip(self):
+        """
+        When a string '*.gz' filename is passed to asHandle, it must be
+        possible to read the correct data from the fp that is returned.
+        """
+        # This test should be better. It should actually create some gzip
+        # compressed data and make sure that it's decompressed
+        # properly. But Python mocking makes me so confused...
+        result = GZIP('xxx')
+
+        with patch.object(gzip, 'GzipFile') as mockMethod:
+            mockMethod.return_value = result
+            with asHandle('file.gz') as fp:
+                self.assertEqual('xxx', fp.read())


### PR DESCRIPTION
Although there aren't tests for passing .gz and .fasta and open file handles in the `test_fasta*.py` files, those arguments are all tested in `test/test_utils.py` because all the code for opening various file types goes through the `asHandle` function in that file.

Fixes #420.
