### PR TITLE
Add DIAMOND btop processing to get query & subject gaps

### DIFF
--- a/bin/convert-diamond-to-json.py
+++ b/bin/convert-diamond-to-json.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
                 'optionally compressing the output. You *must* invoke '
                 'DIAMOND with the following output specification: '
                 '--outfmt 6 qtitle stitle bitscore evalue qframe qseq '
-                'qstart qend sseq sstart send slen'
+                'qstart qend sseq sstart send slen btop'
                 'Note that only each line of the output is JSON (the full '
                 'output is not valid JSON by itself).')
     )

--- a/dark/btop.py
+++ b/dark/btop.py
@@ -8,7 +8,7 @@ def parseBtop(s):
         in C{s}.
     """
     isdigit = str.isdigit
-    value = 0
+    value = None
     queryLetter = None
     for offset, char in enumerate(s):
         if isdigit(char):
@@ -17,11 +17,11 @@ def parseBtop(s):
                     'btop string %r has a query letter %r at offset %d with '
                     'no corresponding subject letter' %
                     (s, queryLetter, offset - 1))
-            value = value * 10 + int(char)
+            value = int(char) if value is None else value * 10 + int(char)
         else:
-            if value:
+            if value is not None:
                 yield value
-                value = 0
+                value = None
                 queryLetter = char
             else:
                 if queryLetter is None:
@@ -38,7 +38,7 @@ def parseBtop(s):
                     yield (queryLetter, char)
                     queryLetter = None
 
-    if value:
+    if value is not None:
         yield value
     elif queryLetter is not None:
         raise ValueError('btop string %r has a trailing query letter %r with '

--- a/dark/btop.py
+++ b/dark/btop.py
@@ -1,0 +1,63 @@
+def parseBtop(s):
+    """
+    Parse a btop string.
+
+    @param s: A C{str} btop sequence.
+    @raise ValueError: If C{s} is not valid btop.
+    @return: A generator that yields integers and 2-tuples of letters, as found
+        in C{s}.
+    """
+    isdigit = str.isdigit
+    value = 0
+    queryLetter = None
+    for offset, char in enumerate(s):
+        if isdigit(char):
+            if queryLetter is not None:
+                raise ValueError(
+                    'btop string %r has a query letter %r at offset %d with '
+                    'no corresponding subject letter' %
+                    (s, queryLetter, offset - 1))
+            value = value * 10 + int(char)
+        else:
+            if value:
+                yield value
+                value = 0
+                queryLetter = char
+            else:
+                if queryLetter is None:
+                    queryLetter = char
+                else:
+                    if queryLetter == '-' and char == '-':
+                        raise ValueError(
+                            'btop string %r has two consecutive gaps at '
+                            'offset %d' % (s, offset - 1))
+                    elif queryLetter == char:
+                        raise ValueError(
+                            'btop string %r has two consecutive identical %r '
+                            'letters at offset %d' % (s, char, offset - 1))
+                    yield (queryLetter, char)
+                    queryLetter = None
+
+    if value:
+        yield value
+    elif queryLetter is not None:
+        raise ValueError('btop string %r has a trailing query letter %r with '
+                         'no corresponding subject letter' % (s, queryLetter))
+
+
+def countGaps(s):
+    """
+    Count the query and subject gaps in a btop string.
+
+    @raises ValueError: If L{parseBtop} finds an error in the btop string C{s}.
+    @return: A 2-tuple of C{int}s, with the (query, subject) gaps counts as
+        found in C{s}.
+    """
+    queryGaps = subjectGaps = 0
+    for countOrMismatch in parseBtop(s):
+        if isinstance(countOrMismatch, tuple):
+            queryChar, subjectChar = countOrMismatch
+            queryGaps += int(queryChar == '-')
+            subjectGaps += int(subjectChar == '-')
+
+    return (queryGaps, subjectGaps)

--- a/dark/diamond/conversion.py
+++ b/dark/diamond/conversion.py
@@ -20,7 +20,7 @@ class DiamondTabularFormatReader(object):
 
     Make sure you run DIAMOND with the right output format. You must use:
         --outfmt 6 qtitle stitle bitscore evalue qframe qseq qstart qend sseq
-                   sstart send slen
+                   sstart send slen btop
 
     @param filename: A C{str} filename or an open file pointer, containing
         DIAMOND tabular records.
@@ -50,10 +50,12 @@ class DiamondTabularFormatReader(object):
             subjectsSeen = {}
             record = {}
             for line in fp:
+                line = line[:-1]
                 (qtitle, stitle, bitscore, evalue, qframe, qseq, qstart, qend,
-                 sseq, sstart, send, slen) = line.split('\t')
+                 sseq, sstart, send, slen, btop) = line.split('\t')
                 hsp = {
                     'bits': float(bitscore),
+                    'btop': btop,
                     'expect': float(evalue),
                     'frame': int(qframe),
                     'query': qseq,

--- a/dark/diamond/hsp.py
+++ b/dark/diamond/hsp.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function
 import sys
 
+from dark.btop import countGaps
+
 
 def _debugPrint(hsp, queryLen, localDict, msg=''):
     """
@@ -17,9 +19,9 @@ def _debugPrint(hsp, queryLen, localDict, msg=''):
     print('  queryLen: %d' % queryLen, file=sys.stderr)
 
     print('  Original HSP:', file=sys.stderr)
-    for attr in ['bits', 'expect', 'frame', 'query_end', 'query_start',
+    for attr in ['bits', 'btop', 'expect', 'frame', 'query_end', 'query_start',
                  'sbjct', 'query', 'sbjct_end', 'sbjct_start']:
-        print('    %s: %s' % (attr, hsp[attr]), file=sys.stderr)
+        print('    %s: %r' % (attr, hsp[attr]), file=sys.stderr)
 
     print('  Local variables:', file=sys.stderr)
     for var in sorted(localDict):
@@ -61,8 +63,7 @@ def _sanityCheck(subjectStart, subjectEnd, queryStart, queryEnd,
     queryMatchLength = queryEnd - queryStart
 
     # Sanity check that the length of the matches in the subject and query
-    # are identical, taking into account gaps in either (indicated by '-'
-    # characters in the match sequences, as returned by DIAMOND).
+    # are identical, taking into account gaps in both.
     subjectMatchLengthWithGaps = subjectMatchLength + subjectGaps
     queryMatchLengthWithGaps = queryMatchLength + queryGaps
     if subjectMatchLengthWithGaps != queryMatchLengthWithGaps:
@@ -122,11 +123,7 @@ def normalizeHSP(hsp, queryLen, diamondTask):
         The returned offset values are all zero-based.
     """
 
-    # TODO: DIAMOND does not show gaps yet. When they start doing that, the
-    # following might have to be changed (or we might have to ask it to
-    # output attributes with different names).
-    subjectGaps = hsp['sbjct'].count('-')
-    queryGaps = hsp['query'].count('-')
+    queryGaps, subjectGaps = countGaps(hsp['btop'])
 
     # Make some variables using Python's standard string indexing (start
     # offset included, end offset not). No calculations in this function

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.51',
+      version='1.0.52',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/diamond/sample_data.py
+++ b/test/diamond/sample_data.py
@@ -14,15 +14,16 @@ RECORD0 = {
             'length': 37000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 20,
                     'sbjct_end': 15400,
                     'expect': 1e-11,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 15390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Squirrelpox virus 1296/99',
@@ -31,15 +32,16 @@ RECORD0 = {
             'length': 38000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 25,
                     'sbjct_end': 12400,
                     'expect': 1e-10,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 12390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Squirrelpox virus 55',
@@ -54,15 +56,16 @@ RECORD1 = {
             'length': 35000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 20,
                     'sbjct_end': 11400,
                     'expect': 1e-8,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 11390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Monkeypox virus 456',
@@ -71,15 +74,16 @@ RECORD1 = {
             'length': 35000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 20,
                     'sbjct_end': 10400,
                     'expect': 1e-7,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAA-AAAAAA',
                     'sbjct_start': 10390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Mummypox virus 3000 B.C.',
@@ -94,15 +98,16 @@ RECORD2 = {
             'length': 30000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 20,
                     'sbjct_end': 1400,
                     'expect': 1e-6,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 1390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Cowpox virus 15',
@@ -118,15 +123,16 @@ RECORD3 = {
             'length': 30000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 20,
                     'sbjct_end': 1400,
                     'expect': 1e-5,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 1390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Cowpox virus 15',
@@ -141,37 +147,40 @@ RECORD4 = {
             'length': 30000,
             'hsps': [
                 {
+                    'btop': '',
                     'bits': 10,
                     'sbjct_end': 1400,
                     'expect': 1e-3,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 1390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 },
                 {
+                    'btop': '',
                     'bits': 5,
                     'sbjct_end': 1400,
                     'expect': 1e-2,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 1390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 },
                 {
+                    'btop': '',
                     'bits': 3,
                     'sbjct_end': 1400,
                     'expect': 0.0,
-                    'sbjct': 'AAAAA--AA-AAAA',
+                    'sbjct': 'AAAAAAAAAAA',
                     'sbjct_start': 1390,
-                    'query': 'TACCCTGCGGCCCGCTACGGCTGG-TCTCCA',
+                    'query': 'TACCCTGCGGCCCGCTACGGCTGGTCTCCATTT',
                     'frame': 1,
                     'query_end': 68,
-                    'query_start': 28
+                    'query_start': 36
                 }
             ],
             'title': 'gi|887699|gb|DQ37780 Cowpox virus 15',

--- a/test/diamond/test_alignments.py
+++ b/test/diamond/test_alignments.py
@@ -483,6 +483,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 150,
+                            "btop": "",
                             "query_start": 362
                         },
                     ],
@@ -502,6 +503,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 180,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -545,6 +547,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 150,
+                            "btop": "",
                             "query_start": 362
                         },
                     ],
@@ -564,6 +567,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 180,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -607,6 +611,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 150,
+                            "btop": "",
                             "query_start": 362
                         },
                     ],
@@ -626,6 +631,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 180,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -670,6 +676,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 150,
+                            "btop": "",
                             "query_start": 362
                         },
                         {
@@ -683,6 +690,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 170,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -702,6 +710,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 180,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -751,6 +760,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 150,
+                            "btop": "",
                             "query_start": 362
                         },
                         {
@@ -764,6 +774,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 170,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],
@@ -783,6 +794,7 @@ class TestDiamondReadsAlignmentsFiltering(TestCase):
                             "frame": 1,
                             "query_end": 462,
                             "bits": 180,
+                            "btop": "",
                             "query_start": 362
                         }
                     ],

--- a/test/diamond/test_conversion.py
+++ b/test/diamond/test_conversion.py
@@ -18,22 +18,28 @@ from dark.diamond.conversion import (JSONRecordsReader,
 from dark.reads import Reads, AARead
 
 
+# The 13 fields expected in the DIAMOND output we parse are:
+#
+# qtitle, stitle, bitscore, evalue, qframe, qseq, qstart, qend, sseq, sstart,
+# send, slen, btop
+#
+# See the --outfmt section of 'diamond help' for detail on these directives.
 DIAMOND_RECORDS = """\
-ACC94	INSV	29.6	0.003	1	EFII	178	295	SSSEV	175	285	295
-ACC94	CASV	28.1	0.008	1	KLL	7	37	ITRV	9	39	300
-ACC94	GoldenGate	28.1	0.009	1	IKSKL	7	35	EETSR	9	37	293
-ACC94	GoldenGate	23.5	0.21	1	TIMSVV	177	240	DDMV	179	235	293
-ACC94	InfluenzaC	25.0	0.084	1	LHVNYL	1	203	DEELKA	2	210	290
-ACC94	InfluenzaC	18.5	9.1	1	SEIICEVLK	226	257	VETVAQ	20	45	290
-ACC94	FERV	24.6	0.11	1	YSCFT-NSEK	176	276	LGKRMFC	152	243	270
-AKAV	AKAV	634	0.0	1	GEPFSVYG	1	306	NIYGEP	1	306	306
-AKAV	WYOV	401	7e-143	1	PFSVYGRF	1	306	GEPMS	1	294	294
-BHAV	TAIV	28.1	0.008	1	PKELHGLI	14	118	SLKSKE	15	131	307
-BHAV	SouthBay	28.1	0.009	1	CRPTF	4	293	EFVFIY	6	342	343
+ACC94	INSV	29.6	0.003	1	EFII	178	295	SSSEV	175	285	295	4
+ACC94	CASV	28.1	0.008	1	KLL	7	37	ITRV	9	39	300	3
+ACC94	GoldenGate	28.1	0.009	1	IKSKL	7	35	EETSR	9	37	293	5
+ACC94	GoldenGate	23.5	0.21	1	TIMSVV	177	240	DDMV	179	235	293	6
+ACC94	InfluenzaC	25.0	0.084	1	LHVNYL	1	203	DEELKA	2	210	290	6
+ACC94	InfluenzaC	18.5	9.1	1	SEIICEVLK	226	257	VETVAQ	20	45	290	9
+ACC94	FERV	24.6	0.11	1	YSCFT-NSEK	176	276	LGKRMFC	152	243	270	10
+AKAV	AKAV	634	0.0	1	GEPFSVYG	1	306	NIYGEP	1	306	306	8
+AKAV	WYOV	401	7e-143	1	PFSVYGRF	1	306	GEPMS	1	294	294	8
+BHAV	TAIV	28.1	0.008	1	PKELHGLI	14	118	SLKSKE	15	131	307	8
+BHAV	SouthBay	28.1	0.009	1	CRPTF	4	293	EFVFIY	6	342	343	5
 """
 
-DIAMOND_RECORDS_SPACES = """\
-ACC 94	IN SV	29.6	0.003	1	EFII	178	295	SSSEV	175	285	295
+DIAMOND_RECORD_WITH_SPACES = """\
+ACC 94	IN SV	29.6	0.003	1	EFII	178	295	SSSEV	175	285	295	4
 """
 
 DIAMOND_RECORDS_DUMPED = '\n'.join([
@@ -51,6 +57,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 29.6,
+                        "btop": "4",
                         "expect": 0.003,
                         "frame": 1,
                         "query": "EFII",
@@ -68,6 +75,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 28.1,
+                        "btop": "3",
                         "expect": 0.008,
                         "frame": 1,
                         "query": "KLL",
@@ -85,6 +93,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 28.1,
+                        "btop": "5",
                         "expect": 0.009,
                         "frame": 1,
                         "query": "IKSKL",
@@ -96,6 +105,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                     },
                     {
                         "bits": 23.5,
+                        "btop": "6",
                         "expect": 0.21,
                         "frame": 1,
                         "query": "TIMSVV",
@@ -113,6 +123,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 25.0,
+                        "btop": "6",
                         "expect": 0.084,
                         "frame": 1,
                         "query": "LHVNYL",
@@ -124,6 +135,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                     },
                     {
                         "bits": 18.5,
+                        "btop": "9",
                         "expect": 9.1,
                         "frame": 1,
                         "query": "SEIICEVLK",
@@ -141,6 +153,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 24.6,
+                        "btop": "10",
                         "expect": 0.11,
                         "frame": 1,
                         "query": "YSCFT-NSEK",
@@ -163,6 +176,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 634.0,
+                        "btop": "8",
                         "expect": 0.0,
                         "frame": 1,
                         "query": "GEPFSVYG",
@@ -180,6 +194,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 401.0,
+                        "btop": "8",
                         "expect": 7e-143,
                         "frame": 1,
                         "query": "PFSVYGRF",
@@ -202,6 +217,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 28.1,
+                        "btop": "8",
                         "expect": 0.008,
                         "frame": 1,
                         "query": "PKELHGLI",
@@ -219,6 +235,7 @@ DIAMOND_RECORDS_DUMPED = '\n'.join([
                 "hsps": [
                     {
                         "bits": 28.1,
+                        "btop": "5",
                         "expect": 0.009,
                         "frame": 1,
                         "query": "CRPTF",
@@ -286,6 +303,7 @@ class TestDiamondTabularFormatReader(TestCase):
             reader = DiamondTabularFormatReader('file.txt')
             fp = StringIO()
             reader.saveAsJSON(fp)
+            self.maxDiff = None
             self.assertEqual(DIAMOND_RECORDS_DUMPED, fp.getvalue())
 
     def testSaveAsJSONBzip2(self):
@@ -309,7 +327,7 @@ class TestDiamondTabularFormatReader(TestCase):
         If there are spaces in the query title or subject titles, the spaces
         must be preserved.
         """
-        mockOpener = mockOpen(read_data=DIAMOND_RECORDS_SPACES)
+        mockOpener = mockOpen(read_data=DIAMOND_RECORD_WITH_SPACES)
         with patch.object(builtins, 'open', mockOpener):
             reader = DiamondTabularFormatReader('file.txt')
             acc94 = list(reader.records())
@@ -335,6 +353,7 @@ _JSON_RECORDS = [
                         'sbjct_start': 1817,
                         'sbjct_end': 1849,
                         'bits': 165.393,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 2.73597e-40,
@@ -359,6 +378,7 @@ _JSON_RECORDS = [
                         'sbjct_start': 4074,
                         'sbjct_end': 4106,
                         'bits': 178.016,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 4.33545e-44,
@@ -378,6 +398,7 @@ _JSON_RECORDS = [
                         'sbjct_start': 4062,
                         'sbjct_end': 4094,
                         'bits': 123.915,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 8.37678e-28,
@@ -397,6 +418,7 @@ _JSON_RECORDS = [
                         'sbjct_start': 4039,
                         'sbjct_end': 4070,
                         'bits': 87.848,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 2,
                         'expect': 6.03169e-17,
@@ -441,6 +463,7 @@ _JSON_RECORDS_ONE_MIDDLE = [
                         'sbjct_start': 1817,
                         'sbjct_end': 1849,
                         'bits': 165.393,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 2.73597e-40,
@@ -465,6 +488,7 @@ _JSON_RECORDS_ONE_MIDDLE = [
                         'sbjct_start': 4074,
                         'sbjct_end': 4106,
                         'bits': 178.016,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 4.33545e-44,
@@ -484,6 +508,7 @@ _JSON_RECORDS_ONE_MIDDLE = [
                         'sbjct_start': 4062,
                         'sbjct_end': 4094,
                         'bits': 123.915,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 8.37678e-28,
@@ -503,6 +528,7 @@ _JSON_RECORDS_ONE_MIDDLE = [
                         'sbjct_start': 4039,
                         'sbjct_end': 4070,
                         'bits': 87.848,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 2,
                         'expect': 6.03169e-17,
@@ -543,6 +569,7 @@ _JSON_RECORDS_ONE_END = [
                         'sbjct_start': 1817,
                         'sbjct_end': 1849,
                         'bits': 165.393,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 2.73597e-40,
@@ -567,6 +594,7 @@ _JSON_RECORDS_ONE_END = [
                         'sbjct_start': 4074,
                         'sbjct_end': 4106,
                         'bits': 178.016,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 4.33545e-44,
@@ -586,6 +614,7 @@ _JSON_RECORDS_ONE_END = [
                         'sbjct_start': 4062,
                         'sbjct_end': 4094,
                         'bits': 123.915,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 8.37678e-28,
@@ -605,6 +634,7 @@ _JSON_RECORDS_ONE_END = [
                         'sbjct_start': 4039,
                         'sbjct_end': 4070,
                         'bits': 87.848,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 2,
                         'expect': 6.03169e-17,
@@ -645,6 +675,7 @@ _JSON_RECORDS_ONE_START = [
                         'sbjct_start': 4074,
                         'sbjct_end': 4106,
                         'bits': 178.016,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 4.33545e-44,
@@ -664,6 +695,7 @@ _JSON_RECORDS_ONE_START = [
                         'sbjct_start': 4062,
                         'sbjct_end': 4094,
                         'bits': 123.915,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 8.37678e-28,
@@ -683,6 +715,7 @@ _JSON_RECORDS_ONE_START = [
                         'sbjct_start': 4039,
                         'sbjct_end': 4070,
                         'bits': 87.848,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 2,
                         'expect': 6.03169e-17,
@@ -727,6 +760,7 @@ _JSON_RECORDS_TWO_END = [
                         'sbjct_start': 1817,
                         'sbjct_end': 1849,
                         'bits': 165.393,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 2.73597e-40,
@@ -751,6 +785,7 @@ _JSON_RECORDS_TWO_END = [
                         'sbjct_start': 4074,
                         'sbjct_end': 4106,
                         'bits': 178.016,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 4.33545e-44,
@@ -770,6 +805,7 @@ _JSON_RECORDS_TWO_END = [
                         'sbjct_start': 4062,
                         'sbjct_end': 4094,
                         'bits': 123.915,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 1,
                         'expect': 8.37678e-28,
@@ -789,6 +825,7 @@ _JSON_RECORDS_TWO_END = [
                         'sbjct_start': 4039,
                         'sbjct_end': 4070,
                         'bits': 87.848,
+                        'btop': '',
                         'frame': 1,
                         'query_start': 2,
                         'expect': 6.03169e-17,

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -1890,3 +1890,100 @@ class TestBlastxFramePlus2WithGaps(TestCase):
             'readStartInSubject': 1,
             'readEndInSubject': 5,
         }, normalized)
+
+
+class TestBlastxFrameMinus1WithGaps(TestCase):
+    """
+    Tests for normalizeHSP for DIAMOND blastx output when frame=-1 (i.e., the
+    query matches in the order it was given to DIAMOND, and the translation
+    frame starts at the second nucleotide) and with gaps.
+    """
+
+    # All query offsets and lengths must be in terms of nucleotides.
+    # Subject offsets are in terms of protein AA sequences.  This is how
+    # DIAMOND reports those offsets.
+    #
+    # In the little diagrams in the docstrings below, the first line is the
+    # subject and the second the query. Dots indicate where the matched
+    # region is. The queries are shown translated so as to line up properly
+    # with the subjects. Gaps are shown as a hyphen.
+
+    def testIdenticalWithQueryGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the query.
+
+             ....
+             .-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=10, queryEnd=2,
+                      frame=-1, btop='1-K2')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoQueryGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the query.
+
+             ....
+             .--.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=7, queryEnd=2,
+                      frame=-1, btop='1-K-K1')
+        normalized = normalizeHSP(hsp, 7, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 2,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithSubjectGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the subject.
+
+             .-..
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=13, queryEnd=2,
+                      frame=-1, btop='1K-2')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoSubjectGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the subject.
+
+             .--.
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=2, queryStart=13, queryEnd=2,
+                      frame=-1, btop='1K-K-1')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 2,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -5,7 +5,7 @@ from dark.diamond.hsp import normalizeHSP
 
 class FakeHSP(dict):
     def __init__(self, subjectStart, subjectEnd, queryStart, queryEnd, frame,
-                 subject='', query='', bitscore=None, evalue=None):
+                 subject='', query='', bitscore=None, evalue=None, btop=''):
         """
         A fake HSP class with 1-based offsets and key names as used by DIAMOND.
         """
@@ -29,6 +29,7 @@ class FakeHSP(dict):
         self['query'] = query
         self['bits'] = bitscore
         self['expect'] = evalue
+        self['btop'] = btop
 
 
 class TestBlastxFramePlus1(TestCase):

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -36,7 +36,7 @@ class TestBlastxFramePlus1(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=1 (i.e., the
     query matches in the order it was given to DIAMOND, and the translation
-    frame starts at the first nucleotide.
+    frame starts at the first nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -187,7 +187,7 @@ class TestBlastxFramePlus2(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=2 (i.e., the
     query matches in the order it was given to DIAMOND, and the translation
-    frame starts at the first nucleotide.
+    frame starts at the second nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -338,7 +338,7 @@ class TestBlastxFramePlus3(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=3 (i.e., the
     query matches in the order it was given to DIAMOND, and the translation
-    frame starts at the first nucleotide.
+    frame starts at the third nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -489,7 +489,7 @@ class TestBlastxFrameMinus1(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=-1 (i.e., the
     query matches in the reverse (complemented) order it was given to DIAMOND,
-    and the translation frame starts at the last nucleotide.
+    and the translation frame starts at the last nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -640,7 +640,7 @@ class TestBlastxFrameMinus2(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=-2 (i.e., the
     query matches in the reverse (complemented) order it was given to DIAMOND,
-    and the translation frame starts at the last nucleotide.
+    and the translation frame starts at the second last nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -791,7 +791,7 @@ class TestBlastxFrameMinus3(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=-3 (i.e., the
     query matches in the reverse (complemented) order it was given to DIAMOND,
-    and the translation frame starts at the last nucleotide.
+    and the translation frame starts at the third last nucleotide).
     """
 
     # All query offsets and lengths must be in terms of nucleotides.
@@ -928,6 +928,463 @@ class TestBlastxFrameMinus3(TestCase):
         hsp = FakeHSP(subjectStart=2, subjectEnd=4, queryStart=12, queryEnd=4,
                       frame=-3)
         normalized = normalizeHSP(hsp, 14, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)
+
+
+class TestBlastxFramePlus1WithGaps(TestCase):
+    """
+    Tests for normalizeHSP for DIAMOND blastx output when frame=1 (i.e., the
+    query matches in the order it was given to DIAMOND, and the translation
+    frame starts at the first nucleotide) and with gaps.
+    """
+
+    # All query offsets and lengths must be in terms of nucleotides.
+    # Subject offsets are in terms of protein AA sequences.  This is how
+    # DIAMOND reports those offsets.
+    #
+    # In the little diagrams in the docstrings below, the first line is the
+    # subject and the second the query. Dots indicate where the matched
+    # region is. The queries are shown translated so as to line up properly
+    # with the subjects. Gaps are shown as a hyphen.
+
+    def testIdenticalWithQueryGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the query.
+
+             ....
+             .-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=1, queryEnd=9,
+                      frame=1, btop='1-K2')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoQueryGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the query.
+
+             ....
+             .--.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=1, queryEnd=6,
+                      frame=1, btop='1-K-K1')
+        normalized = normalizeHSP(hsp, 6, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 2,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithSubjectGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the subject.
+
+             .-..
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=12,
+                      frame=1, btop='1K-2')
+        normalized = normalizeHSP(hsp, 12, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoSubjectGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the subject.
+
+             .--.
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=2, queryStart=1, queryEnd=12,
+                      frame=1, btop='1K-K-1')
+        normalized = normalizeHSP(hsp, 12, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 2,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithQueryAndSubjectGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the query and one in the subject.
+
+             .-..
+             ..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=9,
+                      frame=1, btop='1K--K2')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithQueryGap(self):
+        """
+        The subject overlaps the translated query to the left. The query has a
+        gap.
+
+              ss....
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=6, queryStart=1, queryEnd=9,
+                      frame=1, btop='2-K1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 6,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithSubjectGap(self):
+        """
+        The subject overlaps the translated query to the left. The subject has
+        a gap.
+
+              ss.-..
+                ....
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=5, queryStart=1, queryEnd=12,
+                      frame=1, btop='1K-2')
+        normalized = normalizeHSP(hsp, 12, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithQueryAndSubjectGap(self):
+        """
+        The subject overlaps the translated query to the left. The query and
+        subject both have a gap.
+
+              ss.-..
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=5, queryStart=1, queryEnd=9,
+                      frame=1, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsLeftWithQueryGap(self):
+        """
+        The translated query extends to the left of the subject and the query
+        has a gap.
+
+               ....
+             qq..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=7, queryEnd=15,
+                      frame=1, btop='2-K1')
+        normalized = normalizeHSP(hsp, 15, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsLeftWithSubjectGap(self):
+        """
+        The translated query extends to the left of the subject and the subject
+        has a gap.
+
+               ..-.
+             qq....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=7, queryEnd=18,
+                      frame=1, btop='2K-1')
+        normalized = normalizeHSP(hsp, 18, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 6,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsLeftWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the left of the subject and the query
+        and subject have a gap.
+
+               ..-.
+             qq.-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=7, queryEnd=15,
+                      frame=1, btop='1-KK-1')
+        normalized = normalizeHSP(hsp, 15, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithQueryGap(self):
+        """
+        The subject extends to the right of the translated query and the query
+        has a gap.
+
+               ....ss
+               ..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=1, queryEnd=9,
+                      frame=1, btop='2-K1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithSubjectGap(self):
+        """
+        The subject extends to the right of the translated query and the
+        subject has a gap.
+
+               ..-.ss
+               ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=12,
+                      frame=1, btop='2K-1')
+        normalized = normalizeHSP(hsp, 12, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithQueryAndSubjectGap(self):
+        """
+        The subject extends to the right of the translated query and the
+        query and subject both have gaps.
+
+               ..-.ss
+               .-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=9,
+                      frame=1, btop='2-KK-1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsRightWithQueryGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        query has a gap.
+
+               ....
+               ..-.qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=1, queryEnd=9,
+                      frame=1, btop='2-K1')
+        normalized = normalizeHSP(hsp, 15, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightWithSubjectGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        subject has a gap.
+
+               ..-.
+               ....qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=12,
+                      frame=1, btop='2K-1')
+        normalized = normalizeHSP(hsp, 18, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        query and subject both have a gap.
+
+               ..-.
+               .-..qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=1, queryEnd=9,
+                      frame=1, btop='1-KK-1')
+        normalized = normalizeHSP(hsp, 15, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithQueryGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the query and the query has a gap.
+
+                ....
+              qq.-..q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=7, queryEnd=15,
+                      frame=1, btop='1-K2')
+        normalized = normalizeHSP(hsp, 18, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithSubjectGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the query and the subject has a gap.
+
+                .-..
+              qq....q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=7, queryEnd=18,
+                      frame=1, btop='1K-2')
+        normalized = normalizeHSP(hsp, 21, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 6,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithQueryGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the query has a gap.
+
+               s....ss
+                .-..
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=5, queryStart=3, queryEnd=9,
+                      frame=1, btop='1-K1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithSubjectGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the subject has a gap.
+
+               s.-..ss
+                ....
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=4, queryStart=3, queryEnd=12,
+                      frame=1, btop='1K-1')
+        normalized = normalizeHSP(hsp, 12, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithQueryAndSubjectGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the query and subjects have gaps.
+
+               s.-..ss
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=4, queryStart=3, queryEnd=9,
+                      frame=1, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 9, 'blastx')
         self.assertEqual({
             'subjectStart': 1,
             'subjectEnd': 4,

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -1157,7 +1157,7 @@ class TestBlastxFramePlus1WithGaps(TestCase):
     def testQueryExtendsLeftWithQueryAndSubjectGap(self):
         """
         The translated query extends to the left of the subject and the query
-        and subject have a gap.
+        and subject have gaps.
 
                ..-.
              qq.-..
@@ -1277,7 +1277,7 @@ class TestBlastxFramePlus1WithGaps(TestCase):
     def testQueryExtendsRightWithQueryAndSubjectGap(self):
         """
         The translated query extends to the right of the subject and the
-        query and subject both have a gap.
+        query and subject both have gaps.
 
                ..-.
                .-..qq
@@ -1297,7 +1297,7 @@ class TestBlastxFramePlus1WithGaps(TestCase):
     def testQueryExtendsRightAndLeftWithQueryGap(self):
         """
         The translated query extends to the right and left of the subject and
-        the query and the query has a gap.
+        the query has a gap.
 
                 ....
               qq.-..q
@@ -1317,7 +1317,7 @@ class TestBlastxFramePlus1WithGaps(TestCase):
     def testQueryExtendsRightAndLeftWithSubjectGap(self):
         """
         The translated query extends to the right and left of the subject and
-        the query and the subject has a gap.
+        the subject has a gap.
 
                 .-..
               qq....q
@@ -1330,6 +1330,26 @@ class TestBlastxFramePlus1WithGaps(TestCase):
             'subjectEnd': 3,
             'readStart': 2,
             'readEnd': 6,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the query and the subject have gaps.
+
+                .-..
+              qq..-.q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=7, queryEnd=15,
+                      frame=1, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 18, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 5,
             'readStartInSubject': -2,
             'readEndInSubject': 5,
         }, normalized)

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -1895,8 +1895,8 @@ class TestBlastxFramePlus2WithGaps(TestCase):
 class TestBlastxFrameMinus1WithGaps(TestCase):
     """
     Tests for normalizeHSP for DIAMOND blastx output when frame=-1 (i.e., the
-    query matches in the order it was given to DIAMOND, and the translation
-    frame starts at the second nucleotide) and with gaps.
+    query matches in the reverse (complemented) order it was given to DIAMOND,
+    and the translation frame starts at the last nucleotide) and with gaps.
     """
 
     # All query offsets and lengths must be in terms of nucleotides.

--- a/test/diamond/test_hsp.py
+++ b/test/diamond/test_hsp.py
@@ -1413,3 +1413,480 @@ class TestBlastxFramePlus1WithGaps(TestCase):
             'readStartInSubject': 1,
             'readEndInSubject': 5,
         }, normalized)
+
+
+class TestBlastxFramePlus2WithGaps(TestCase):
+    """
+    Tests for normalizeHSP for DIAMOND blastx output when frame=2 (i.e., the
+    query matches in the order it was given to DIAMOND, and the translation
+    frame starts at the second nucleotide) and with gaps.
+    """
+
+    # All query offsets and lengths must be in terms of nucleotides.
+    # Subject offsets are in terms of protein AA sequences.  This is how
+    # DIAMOND reports those offsets.
+    #
+    # In the little diagrams in the docstrings below, the first line is the
+    # subject and the second the query. Dots indicate where the matched
+    # region is. The queries are shown translated so as to line up properly
+    # with the subjects. Gaps are shown as a hyphen.
+
+    def testIdenticalWithQueryGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the query.
+
+             ....
+             .-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=2, queryEnd=10,
+                      frame=2, btop='1-K2')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoQueryGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the query.
+
+             ....
+             .--.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=2, queryEnd=7,
+                      frame=2, btop='1-K-K1')
+        normalized = normalizeHSP(hsp, 7, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 2,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithSubjectGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the subject.
+
+             .-..
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=13,
+                      frame=2, btop='1K-2')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithTwoSubjectGaps(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given two gaps in the subject.
+
+             .--.
+             ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=2, queryStart=2, queryEnd=13,
+                      frame=2, btop='1K-K-1')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 2,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testIdenticalWithQueryAndSubjectGap(self):
+        """
+        The subject start and end are identical to those of the translated
+        query, given one gap in the query and one in the subject.
+
+             .-..
+             ..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=10,
+                      frame=2, btop='1K--K2')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithQueryGap(self):
+        """
+        The subject overlaps the translated query to the left. The query has a
+        gap.
+
+              ss....
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=6, queryStart=2, queryEnd=10,
+                      frame=2, btop='2-K1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 6,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithSubjectGap(self):
+        """
+        The subject overlaps the translated query to the left. The subject has
+        a gap.
+
+              ss.-..
+                ....
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=5, queryStart=2, queryEnd=13,
+                      frame=2, btop='1K-2')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testSubjectExtendsLeftWithQueryAndSubjectGap(self):
+        """
+        The subject overlaps the translated query to the left. The query and
+        subject both have a gap.
+
+              ss.-..
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=3, subjectEnd=5, queryStart=2, queryEnd=10,
+                      frame=2, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 2,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 2,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsLeftWithQueryGap(self):
+        """
+        The translated query extends to the left of the subject and the query
+        has a gap.
+
+               ....
+             qq..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=8, queryEnd=16,
+                      frame=2, btop='2-K1')
+        normalized = normalizeHSP(hsp, 16, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsLeftWithSubjectGap(self):
+        """
+        The translated query extends to the left of the subject and the subject
+        has a gap.
+
+               ..-.
+             qq....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=8, queryEnd=19,
+                      frame=2, btop='2K-1')
+        normalized = normalizeHSP(hsp, 19, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 6,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsLeftWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the left of the subject and the query
+        and subject have gaps.
+
+               ..-.
+             qq.-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=8, queryEnd=16,
+                      frame=2, btop='1-KK-1')
+        normalized = normalizeHSP(hsp, 16, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithQueryGap(self):
+        """
+        The subject extends to the right of the translated query and the query
+        has a gap.
+
+               ....ss
+               ..-.
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=2, queryEnd=10,
+                      frame=2, btop='2-K1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithSubjectGap(self):
+        """
+        The subject extends to the right of the translated query and the
+        subject has a gap.
+
+               ..-.ss
+               ....
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=13,
+                      frame=2, btop='2K-1')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testSubjectExtendsRightWithQueryAndSubjectGap(self):
+        """
+        The subject extends to the right of the translated query and the
+        query and subject both have gaps.
+
+               ..-.ss
+               .-..
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=10,
+                      frame=2, btop='2-KK-1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 4,
+        }, normalized)
+
+    def testQueryExtendsRightWithQueryGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        query has a gap.
+
+               ....
+               ..-.qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=2, queryEnd=10,
+                      frame=2, btop='2-K1')
+        normalized = normalizeHSP(hsp, 16, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightWithSubjectGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        subject has a gap.
+
+               ..-.
+               ....qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=13,
+                      frame=2, btop='2K-1')
+        normalized = normalizeHSP(hsp, 19, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the right of the subject and the
+        query and subject both have gaps.
+
+               ..-.
+               .-..qq
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=2, queryEnd=10,
+                      frame=2, btop='1-KK-1')
+        normalized = normalizeHSP(hsp, 16, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 0,
+            'readEndInSubject': 6,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithQueryGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the query has a gap.
+
+                ....
+              qq.-..q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=4, queryStart=8, queryEnd=16,
+                      frame=2, btop='1-K2')
+        normalized = normalizeHSP(hsp, 19, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 4,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithSubjectGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the subject has a gap.
+
+                .-..
+              qq....q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=8, queryEnd=19,
+                      frame=2, btop='1K-2')
+        normalized = normalizeHSP(hsp, 22, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 6,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testQueryExtendsRightAndLeftWithQueryAndSubjectGap(self):
+        """
+        The translated query extends to the right and left of the subject and
+        the query and the subject have gaps.
+
+                .-..
+              qq..-.q
+        """
+        hsp = FakeHSP(subjectStart=1, subjectEnd=3, queryStart=8, queryEnd=16,
+                      frame=2, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 19, 'blastx')
+        self.assertEqual({
+            'subjectStart': 0,
+            'subjectEnd': 3,
+            'readStart': 2,
+            'readEnd': 5,
+            'readStartInSubject': -2,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithQueryGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the query has a gap.
+
+               s....ss
+                .-..
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=5, queryStart=4, queryEnd=10,
+                      frame=2, btop='1-K1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 5,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithSubjectGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the subject has a gap.
+
+               s.-..ss
+                ....
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=4, queryStart=4, queryEnd=13,
+                      frame=2, btop='1K-1')
+        normalized = normalizeHSP(hsp, 13, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 4,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)
+
+    def testSubjectExtendsRightAndLeftWithQueryAndSubjectGap(self):
+        """
+        The subject extends to the right and left of the translated query and
+        the query and subjects have gaps.
+
+               s.-..ss
+                ..-.
+        """
+        hsp = FakeHSP(subjectStart=2, subjectEnd=4, queryStart=4, queryEnd=10,
+                      frame=2, btop='1K--K1')
+        normalized = normalizeHSP(hsp, 10, 'blastx')
+        self.assertEqual({
+            'subjectStart': 1,
+            'subjectEnd': 4,
+            'readStart': 0,
+            'readEnd': 3,
+            'readStartInSubject': 1,
+            'readEndInSubject': 5,
+        }, normalized)

--- a/test/test_btop.py
+++ b/test/test_btop.py
@@ -1,0 +1,151 @@
+from six import assertRaisesRegex
+from unittest import TestCase
+
+from dark.btop import countGaps, parseBtop
+
+
+class TestParseBtop(TestCase):
+    """
+    Tests for the parseBtop function.
+    """
+    def testOneLetter(self):
+        """
+        An argument with just one letter must result in a ValueError.
+        """
+        error = ("^btop string 'F' has a trailing query letter 'F' with no "
+                 "corresponding subject letter$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('F'))
+
+    def testConsecutiveGaps(self):
+        """
+        An argument that has two consecutive gaps characters must result in a
+        ValueError.
+        """
+        error = "^btop string '36--' has two consecutive gaps at offset 2$"
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('36--'))
+
+    def testConsecutiveIdentical(self):
+        """
+        An argument that has two consecutive identical (non-gap) characters
+        must result in a ValueError.
+        """
+        error = ("^btop string '36AA' has two consecutive identical 'A' "
+                 "letters at offset 2$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('36AA'))
+
+    def testEmpty(self):
+        """
+        An empty argument must result in an empty list.
+        """
+        self.assertEqual([], list(parseBtop('')))
+
+    def testOneNumberWithTrailingOneLetter(self):
+        """
+        An argument that is a number with a single letter must result in a
+        ValueError.
+        """
+        error = ("^btop string '36F' has a trailing query letter 'F' with no "
+                 "corresponding subject letter$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('36F'))
+
+    def testThreeLetters(self):
+        """
+        An argument that has three letters must result in a ValueError.
+        """
+        error = ("^btop string 'ABC' has a trailing query letter 'C' with no "
+                 "corresponding subject letter$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('ABC'))
+
+    def testOneLetterThenANumber(self):
+        """
+        An argument that is a single letter followed by a number must result
+        in a ValueError.
+        """
+        error = ("^btop string 'F36' has a query letter 'F' at offset 0 with "
+                 "no corresponding subject letter$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('F36'))
+
+    def testTwoNumbersWithOneLetterBetween(self):
+        """
+        An argument that is a number, a single letter, and another number must
+        result in a ValueError.
+        """
+        error = ("^btop string '36F77' has a query letter 'F' at offset 2 "
+                 "with no corresponding subject letter$")
+        assertRaisesRegex(self, ValueError, error, list, parseBtop('36F77'))
+
+    def testOneNumber(self):
+        """
+        An argument that is just one number must give the expected result.
+        """
+        self.assertEqual([54], list(parseBtop('54')))
+
+    def testOneQuerySubjectPair(self):
+        """
+        An argument that is a single query/subject letter pair must give the
+        expected result.
+        """
+        self.assertEqual([('A', 'G')], list(parseBtop('AG')))
+
+    def testTwoQuerySubjectPairs(self):
+        """
+        An argument that has two query/subject letter pairs must give the
+        expected result.
+        """
+        self.assertEqual([('A', 'G'), ('C', 'T')], list(parseBtop('AGCT')))
+
+    def testOneQuerySubjectPairAndANumber(self):
+        """
+        An argument that is a single query/subject letter pair followed by a
+        number must give the expected result.
+        """
+        self.assertEqual([('A', 'G'), 33], list(parseBtop('AG33')))
+
+
+class TestCountGaps(TestCase):
+    """
+    Tests for the countGaps function.
+    """
+    def testEmpty(self):
+        """
+        An argument with an empty string must produce the expected result.
+        """
+        self.assertEqual((0, 0), countGaps(''))
+
+    def testNumberOnly(self):
+        """
+        An argument with just a number must produce the expected result.
+        """
+        self.assertEqual((0, 0), countGaps('88'))
+
+    def testLettersButNoGaps(self):
+        """
+        An argument with just letters must produce the expected result.
+        """
+        self.assertEqual((0, 0), countGaps('FGAC'))
+
+    def testOneQueryGap(self):
+        """
+        An argument with just a query gap must produce the expected result.
+        """
+        self.assertEqual((1, 0), countGaps('-G'))
+
+    def testOneSubjectGap(self):
+        """
+        An argument with just a subject gap must produce the expected result.
+        """
+        self.assertEqual((0, 1), countGaps('G-'))
+
+    def testOneQueryAndOneSubjectGap(self):
+        """
+        An argument with a query and a subject gap must produce the expected
+        result.
+        """
+        self.assertEqual((1, 1), countGaps('G--G'))
+
+    def testMultipleQueryAndSubjectGaps(self):
+        """
+        An argument with multiple query and a subject gaps must produce the
+        expected result.
+        """
+        self.assertEqual((3, 2), countGaps('-GG-34-T-T39F-'))

--- a/test/test_btop.py
+++ b/test/test_btop.py
@@ -80,6 +80,19 @@ class TestParseBtop(TestCase):
         """
         self.assertEqual([54], list(parseBtop('54')))
 
+    def testOneNumberThatIsZero(self):
+        """
+        An argument that is just the number zero must give the expected result.
+        """
+        self.assertEqual([0], list(parseBtop('0')))
+
+    def testOneNumberWithLeadingZeroes(self):
+        """
+        An argument that is just one number with leading zeroes must give the
+        expected result.
+        """
+        self.assertEqual([54], list(parseBtop('0054')))
+
     def testOneQuerySubjectPair(self):
         """
         An argument that is a single query/subject letter pair must give the


### PR DESCRIPTION
This needs some more tests, but you might want to have a look at it already.

Branched from #437.

Fixes #439.