### PR TITLE
Added summary method to TitleAlignments and TitlesAlignments

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """
-Given a BLAST or DIAMOND JSON output files, the corresponding FASTA (or
-FASTQ) sequence files, and filtering criteria, produce an alignment
-panel.
+Given a BLAST or DIAMOND JSON output files, the corresponding FASTA (or FASTQ)
+sequence files, and filtering criteria, produce a summary of matched titles
+and (optionally) an alignment panel.
 
 Run with --help for help.
 """
@@ -286,16 +286,17 @@ if __name__ == '__main__':
         sortOn=args.sortOn, minCoverage=args.minCoverage)
 
     nTitles = len(titlesAlignments)
-    print('Found %d interesting title%s.' % (nTitles,
-                                             '' if nTitles == 1 else 's'))
+    print('Found %d interesting title%s.' %
+          (nTitles, '' if nTitles == 1 else 's'), file=sys.stderr)
 
-    if nTitles == 0:
-        print('No alignment panel generated due to no matching titles.')
-        sys.exit(0)
+    print(titlesAlignments.tabSeparatedSummary(sortBy=args.sortOn))
 
     if args.earlyExit:
-        print('Matched titles (sorted by %s):' % args.sortOn)
-        print('\n'.join(titlesAlignments.sortTitles(args.sortOn)))
+        sys.exit(0)
+
+    if nTitles == 0:
+        print('No alignment panel generated due to no matching titles.',
+              file=sys.stderr)
         sys.exit(0)
 
     alignmentPanel(titlesAlignments, sortOn=args.sortOn, interactive=False,

--- a/dark/titles.py
+++ b/dark/titles.py
@@ -403,18 +403,54 @@ class TitlesAlignments(dict):
         raise ValueError('Sort attribute must be one of "length", "maxScore", '
                          '"medianScore", "readCount", "title".')
 
-    def summary(self, sortBy=None):
+    def summary(self, sortOn=None):
         """
         Summarize all the alignments for this title.
 
-        @param sortBy: A C{str}, one of 'length', 'maxScore', 'medianScore',
-            'readCount', or 'title'.
-        @raise ValueError: If an unknown C{sortBy} value is given.
+        @param sortOn: A C{str} attribute to sort titles on. One of 'length',
+            'maxScore', 'medianScore', 'readCount', or 'title'.
+        @raise ValueError: If an unknown C{sortOn} value is given.
         @return: A generator that yields C{dict} instances as produced by
             C{TitleAlignments} (see class earlier in this file), sorted by
-            C{sortBy}.
+            C{sortOn}.
         """
-        titles = self if sortBy is None else self.sortTitles(sortBy)
+        titles = self if sortOn is None else self.sortTitles(sortOn)
 
         for title in titles:
             yield self[title].summary()
+
+    def tabSeparatedSummary(self, sortOn=None):
+        """
+        Summarize all the alignments for this title as multi-line string with
+        TAB-separated values on each line.
+
+        @param sortOn: A C{str} attribute to sort titles on. One of 'length',
+            'maxScore', 'medianScore', 'readCount', or 'title'.
+        @raise ValueError: If an unknown C{sortOn} value is given.
+        @return: A newline-separated C{str}, each line with a summary of a
+            title. Each summary line is TAB-separated.
+        """
+        # The order of the fields returned here is somewhat arbitrary. The
+        # subject titles are last because they are so variable in length.
+        # Putting them last makes it more likely that the initial columns in
+        # printed output will be easier to read down.
+        #
+        # Note that post-processing scripts will be relying on the field
+        # ordering here.  So you can't just add fields. It's probably safe
+        # to add them at the end, but be careful / think.
+        #
+        # A TAB-separated file can easily be read by awk using e.g.,
+        # awk 'BEGIN {FS = "\t"} ...'
+
+        result = []
+        for titleSummary in self.summary(sortOn):
+            result.append('\t'.join([
+                '%(coverage)f',
+                '%(medianScore)f',
+                '%(bestScore)f',
+                '%(readCount)d',
+                '%(hspCount)d',
+                '%(subjectLength)d',
+                '%(subjectTitle)s',
+            ]) % titleSummary)
+        return '\n'.join(result)

--- a/dark/titles.py
+++ b/dark/titles.py
@@ -62,7 +62,7 @@ class TitleAlignments(list):
 
     def reads(self):
         """
-        Find the set of reads matching a this title.
+        Find the set of reads matching this title.
 
         @return: An instance of C{dark.reads.Reads}.
         """
@@ -192,6 +192,30 @@ class TitleAlignments(list):
                     counts[subjectOffset][convert(residue)] += 1
 
         return counts
+
+    def summary(self):
+        """
+        Summarize the alignments for this subject.
+
+        @return: A C{dict} with C{str} keys:
+            bestScore: The C{float} best score of the matching reads.
+            coverage: The C{float} fraction of the subject genome that is
+                matched by at least one read.
+            hspCount: The C{int} number of hsps that match the subject.
+            medianScore: The C{float} median score of the matching reads.
+            readCount: The C{int} number of reads that match the subject.
+            subjectLength: The C{int} length of the subject.
+            subjectTitle: The C{str} title of the subject.
+        """
+        return {
+            'bestScore': self.bestHsp().score.score,
+            'coverage': self.coverage(),
+            'hspCount': self.hspCount(),
+            'medianScore': self.medianScore(),
+            'readCount': self.readCount(),
+            'subjectLength': self.subjectLength,
+            'subjectTitle': self.subjectTitle,
+        }
 
 
 class TitlesAlignments(dict):
@@ -351,6 +375,7 @@ class TitlesAlignments(dict):
 
         @param by: A C{str}, one of 'length', 'maxScore', 'medianScore',
             'readCount', or 'title'.
+        @raise ValueError: If an unknown C{by} value is given.
         @return: A sorted C{list} of titles.
         """
         # First sort titles by the secondary key, which is always the title.
@@ -377,3 +402,19 @@ class TitlesAlignments(dict):
 
         raise ValueError('Sort attribute must be one of "length", "maxScore", '
                          '"medianScore", "readCount", "title".')
+
+    def summary(self, sortBy=None):
+        """
+        Summarize all the alignments for this title.
+
+        @param sortBy: A C{str}, one of 'length', 'maxScore', 'medianScore',
+            'readCount', or 'title'.
+        @raise ValueError: If an unknown C{sortBy} value is given.
+        @return: A generator that yields C{dict} instances as produced by
+            C{TitleAlignments} (see class earlier in this file), sorted by
+            C{sortBy}.
+        """
+        titles = self if sortBy is None else self.sortTitles(sortBy)
+
+        for title in titles:
+            yield self[title].summary()

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.58',
+      version='1.0.59',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/diamond/test_alignments.py
+++ b/test/diamond/test_alignments.py
@@ -278,8 +278,7 @@ class TestDiamondReadsAlignments(TestCase):
 
     def testGetSubjectSequence(self):
         """
-        The getSubjectSequence function must return a correct C{SeqIO.read}
-        instance.
+        The getSubjectSequence function must return a correct read instance.
         """
         class SideEffect(object):
             def __init__(self, test):

--- a/test/diamond/test_titles.py
+++ b/test/diamond/test_titles.py
@@ -254,7 +254,6 @@ class TestTitlesAlignments(TestCase):
         mockOpener = mockOpen(read_data=(
             dumps(PARAMS) + '\n' + dumps(RECORD0) + '\n' +
             dumps(RECORD1) + '\n'))
-        self.maxDiff = None
         with patch.object(builtins, 'open', mockOpener):
             reads = Reads()
             reads.add(Read('id0', 'A' * 70))
@@ -305,7 +304,37 @@ class TestTitlesAlignments(TestCase):
                             'gi|887699|gb|DQ37780 Squirrelpox virus 55'),
                     },
                 ],
-                list(titlesAlignments.summary(by='title')))
+                list(titlesAlignments.summary(sortOn='title')))
+
+    def testTabSeparatedSummary(self):
+        """
+        The summary function must return the correct result.
+        """
+        mockOpener = mockOpen(read_data=(
+            dumps(PARAMS) + '\n' + dumps(RECORD0) + '\n'))
+        with patch.object(builtins, 'open', mockOpener):
+            reads = Reads()
+            reads.add(Read('id0', 'A' * 70))
+            readsAlignments = DiamondReadsAlignments(reads, 'f.json', 'db')
+            titlesAlignments = TitlesAlignments(readsAlignments)
+            summary = titlesAlignments.tabSeparatedSummary(sortOn='title')
+            expected = (
+                '0.000297\t'
+                '20.000000\t'
+                '20.000000\t'
+                '1\t'
+                '1\t'
+                '37000\t'
+                'gi|887699|gb|DQ37780 Squirrelpox virus 1296/99'
+                '\n'
+                '0.000289\t'
+                '25.000000\t'
+                '25.000000\t'
+                '1\t'
+                '1\t'
+                '38000\t'
+                'gi|887699|gb|DQ37780 Squirrelpox virus 55')
+            self.assertEqual(expected, summary)
 
 
 class TestTitlesAlignmentsFiltering(TestCase):

--- a/test/diamond/test_titles.py
+++ b/test/diamond/test_titles.py
@@ -247,6 +247,66 @@ class TestTitlesAlignments(TestCase):
                 sorted([HSP(20), HSP(25), HSP(20), HSP(20), HSP(20)]),
                 sorted(result))
 
+    def testSummary(self):
+        """
+        The summary function must return the correct result.
+        """
+        mockOpener = mockOpen(read_data=(
+            dumps(PARAMS) + '\n' + dumps(RECORD0) + '\n' +
+            dumps(RECORD1) + '\n'))
+        self.maxDiff = None
+        with patch.object(builtins, 'open', mockOpener):
+            reads = Reads()
+            reads.add(Read('id0', 'A' * 70))
+            reads.add(Read('id1', 'A' * 70))
+            readsAlignments = DiamondReadsAlignments(reads, 'file.json',
+                                                     'database.fasta')
+            titlesAlignments = TitlesAlignments(readsAlignments)
+            self.assertEqual(
+                [
+                    {
+                        'bestScore': 20.0,
+                        'coverage': 0.00031428571428571427,
+                        'hspCount': 1,
+                        'medianScore': 20.0,
+                        'readCount': 1,
+                        'subjectLength': 35000,
+                        'subjectTitle': (
+                            'gi|887699|gb|DQ37780 Monkeypox virus 456'),
+                    },
+                    {
+                        'bestScore': 20.0,
+                        'coverage': 0.00031428571428571427,
+                        'hspCount': 1,
+                        'medianScore': 20.0,
+                        'readCount': 1,
+                        'subjectLength': 35000,
+                        'subjectTitle': (
+                            'gi|887699|gb|DQ37780 Mummypox virus 3000 B.C.'),
+                    },
+                    {
+                        'bestScore': 20.0,
+                        'coverage': 0.0002972972972972973,
+                        'hspCount': 1,
+                        'medianScore': 20.0,
+                        'readCount': 1,
+                        'subjectLength': 37000,
+                        'subjectTitle': (
+                            'gi|887699|gb|DQ37780 Squirrelpox virus 1296/99'),
+                    },
+                    {
+                        'bestScore': 25.0,
+                        'coverage': 0.00028947368421052634,
+                        'hspCount': 1,
+                        'medianScore': 25.0,
+                        'readCount': 1,
+                        'subjectLength': 38000,
+                        'subjectTitle': (
+                            'gi|887699|gb|DQ37780 Squirrelpox virus 55'),
+                    },
+                ],
+                list(titlesAlignments.summary(by='title')))
+
 
 class TestTitlesAlignmentsFiltering(TestCase):
     """

--- a/test/test_titles.py
+++ b/test/test_titles.py
@@ -655,6 +655,41 @@ class TestTitleAlignments(WarningTestMixin, TestCase):
             },
             titleAlignments.residueCounts())
 
+    def testSummaryWhenEmpty(self):
+        """
+        If summary is called on an instance of TitleAlignments with no
+        alignments a ValueError must be raised.
+        """
+        titleAlignments = TitleAlignments('subject title', 55)
+        error = '^max\(\) arg is an empty sequence$'
+        six.assertRaisesRegex(self, ValueError, error, titleAlignments.summary)
+
+    def testSummary(self):
+        """
+        The summary method must return the correct result.
+        """
+        titleAlignments = TitleAlignments('subject title', 10)
+        titleAlignments.addAlignment(
+            TitleAlignment(Read('id1', 'ACGT'), [
+                HSP(30, subjectStart=0, subjectEnd=2),
+            ]))
+        titleAlignments.addAlignment(
+            TitleAlignment(Read('id2', 'ACGT'), [
+                HSP(55, subjectStart=2, subjectEnd=4),
+                HSP(40, subjectStart=8, subjectEnd=9),
+            ]))
+        self.assertEqual(
+            {
+                'bestScore': 55,
+                'coverage': 0.5,
+                'hspCount': 3,
+                'medianScore': 40,
+                'readCount': 2,
+                'subjectLength': 10,
+                'subjectTitle': 'subject title',
+            },
+            titleAlignments.summary())
+
 
 class TestTitleAlignmentsLSP(TestCase):
     """


### PR DESCRIPTION
This isn't done yet, but the underlying summary generation is in place and tested.

It would be good to talk about how to proceed. E.g., print the summary line by line with spaces (printing the title last), printing in as CSV, or HTML. What argument(s) should `noninteractive-alignment-panel.py` take to achieve this, and how should those args behave wrt the existing behavior and args such as `--earlyExit`, etc.?

Fixes #445.
