### PR TITLE
Stop parseColors in noninteractive-alignment-panel.py from raising due to checkAlphabet not being used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.66',
+      version='1.0.67',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
Fixes #451.
