### PR TITLE
Change Reads so it can accept a filterFunc argument

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -28,6 +28,7 @@ from dark.titles import TitlesAlignments
 from dark.fasta import FastaReads
 from dark.fastq import FastqReads
 from dark.graphics import DEFAULT_LOG_LINEAR_X_AXIS_BASE, alignmentPanelHTML
+from dark.reads import ReadFilter
 
 
 def parseColors(colors, args):
@@ -253,9 +254,9 @@ if __name__ == '__main__':
     # Flatten lists of lists that we get from using both nargs='+' and
     # action='append'. We use both because it allows people to use (e.g.)
     # --json on the command line either via "--json file1 --json file2" or
-    # "--json file1 --file2", or a combination of these. That way it's not
-    # necessary to remember which way you're supposed to use it and you also
-    # can't be hit by the subtle problem encountered in
+    # "--json file1 file2", or a combination of these. That way it's not
+    # necessary to remember which way you're supposed to use it and you
+    # also can't be hit by the subtle problem encountered in
     # https://github.com/acorg/dark-matter/issues/453
     jsonFiles = list(chain.from_iterable(args.json))
     whitelist = (
@@ -263,16 +264,27 @@ if __name__ == '__main__':
     blacklist = (
         set(chain.from_iterable(args.blacklist)) if args.blacklist else None)
 
+    readFilter = ReadFilter(
+        minSequenceLen=args.minSequenceLen, maxSequenceLen=args.maxSequenceLen,
+        minStart=args.minStart, maxStop=args.maxStop,
+        oneAlignmentPerRead=args.oneAlignmentPerRead,
+        maxHspsPerHit=args.maxHspsPerHit, scoreCutoff=args.scoreCutoff,
+        whitelist=whitelist, blacklist=blacklist,
+        titleRegex=args.titleRegex, negativeTitleRegex=args.negativeTitleRegex,
+        truncateTitlesAfter=args.truncateTitlesAfter, taxonomy=args.taxonomy)
+
     # TODO: Add a --readClass option in case we want to process AA queries.
     if args.fasta:
         reads = FastaReads(list(chain.from_iterable(args.fasta)),
-                           checkAlphabet=args.checkAlphabet)
+                           checkAlphabet=args.checkAlphabet,
+                           filterFunc=readFilter.filter)
     else:
         if args.checkAlphabet is not None:
             print('--checkAlphabet is currently not supported for FASTQ reads',
                   file=sys.stderr)
             sys.exit(1)
-        reads = FastqReads(list(chain.from_iterable(args.fastq)))
+        reads = FastqReads(list(chain.from_iterable(args.fastq)),
+                           filterFunc=readFilter.filter)
 
     if args.matcher == 'blast':
         from dark.blast.alignments import BlastReadsAlignments
@@ -286,17 +298,6 @@ if __name__ == '__main__':
         from dark.diamond.alignments import DiamondReadsAlignments
         readsAlignments = DiamondReadsAlignments(
             reads, jsonFiles, args.diamondDatabaseFastaFilename)
-
-    readsAlignments.filter(
-        minSequenceLen=args.minSequenceLen,
-        maxSequenceLen=args.maxSequenceLen,
-        minStart=args.minStart, maxStop=args.maxStop,
-        oneAlignmentPerRead=args.oneAlignmentPerRead,
-        maxHspsPerHit=args.maxHspsPerHit,
-        scoreCutoff=args.scoreCutoff,
-        whitelist=whitelist, blacklist=blacklist,
-        titleRegex=args.titleRegex, negativeTitleRegex=args.negativeTitleRegex,
-        truncateTitlesAfter=args.truncateTitlesAfter, taxonomy=args.taxonomy)
 
     titlesAlignments = TitlesAlignments(readsAlignments).filter(
         minMatchingReads=args.minMatchingReads,

--- a/dark/fasta.py
+++ b/dark/fasta.py
@@ -91,9 +91,11 @@ class FastaReads(Reads):
         checked. (Pass zero to have no checks done.)
     @param upperCase: If C{True}, read sequences will be converted to upper
         case.
+    @param filterFunc: A function that takes a C{Read} instance and returns
+        either the read (if it is acceptable to the filter) or C{False}.
     """
     def __init__(self, _files, readClass=DNARead, checkAlphabet=None,
-                 upperCase=False):
+                 upperCase=False, filterFunc=lambda read: read):
         self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
         self._checkAlphabet = checkAlphabet
@@ -106,9 +108,9 @@ class FastaReads(Reads):
         # sequences already added from the file.
         self._upperCase = upperCase
         if PY3:
-            super().__init__()
+            super().__init__(filterFunc=filterFunc)
         else:
-            Reads.__init__(self)
+            Reads.__init__(self, filterFunc=filterFunc)
 
     def iter(self):
         """

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -33,17 +33,19 @@ class SSFastaReads(Reads):
         checked. (Pass zero to have no checks done.)
     @param upperCase: If C{True}, both read and structure sequences will be
         converted to upper case.
+    @param filterFunc: A function that takes a C{Read} instance and returns
+        either the read (if it is acceptable to the filter) or C{False}.
     """
     def __init__(self, _files, readClass=SSAARead, checkAlphabet=None,
-                 upperCase=False):
+                 upperCase=False, filterFunc=lambda read: read):
         self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
         self._checkAlphabet = checkAlphabet
         self._upperCase = upperCase
         if PY3:
-            super().__init__()
+            super().__init__(filterFunc=filterFunc)
         else:
-            Reads.__init__(self)
+            Reads.__init__(self, filterFunc=filterFunc)
 
     def iter(self):
         """

--- a/dark/fastq.py
+++ b/dark/fastq.py
@@ -14,14 +14,17 @@ class FastqReads(Reads):
         C{list} of C{str} file names and/or file handles. Each file or file
         handle must contain sequences in FASTQ format.
     @param readClass: The class of read that should be yielded by iter.
+    @param filterFunc: A function that takes a C{Read} instance and returns
+        either the read (if it is acceptable to the filter) or C{False}.
     """
-    def __init__(self, _files, readClass=DNARead):
+    def __init__(self, _files, readClass=DNARead,
+                 filterFunc=lambda read: read):
         self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self.readClass = readClass
         if PY3:
-            super().__init__()
+            super().__init__(filterFunc=filterFunc)
         else:
-            Reads.__init__(self)
+            Reads.__init__(self, filterFunc=filterFunc)
 
     def iter(self):
         """

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -979,7 +979,7 @@ class Reads(object):
         As a side effect, calculate our length (the number of reads in this
         collection of reads).
 
-        @return: A generator that yields reads. The returned read types depends
+        @return: A generator that yields reads. The returned read types depend
             on the kind of reads that were added to this instance.
         """
         # First return any reads that were added via our 'add' method.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.85',
+      version='1.0.86',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_fasta.py
+++ b/test/test_fasta.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from .mocking import mockOpen, File
 
-from dark.reads import Read, AARead, DNARead, RNARead, Reads
+from dark.reads import Read, AARead, DNARead, RNARead, Reads, ReadFilter
 from dark.fasta import (dedupFasta, dePrefixAndSuffixFasta, fastaSubtract,
                         FastaReads, combineReads)
 
@@ -482,6 +482,21 @@ class TestFastaReads(TestCase):
             reads = FastaReads('filename.fasta')
             result = list(reads.filter(randomSubset=1, trueLength=10))
             self.assertEqual(1, len(result))
+
+    def testDirectFiltering(self):
+        """
+        It must be possible to directly use a ReadFilter to filter the reads
+        that end up in a FastaReads instance (from the reads that are read
+        from the input file).
+        """
+        data = '\n'.join(['>one', 'atat',
+                          '>two', 'atcg'])
+        readFilter = ReadFilter(head=1)
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = FastaReads(data, readClass=AARead,
+                               filterFunc=readFilter.filter)
+            self.assertEqual([Read('one', 'atat')], list(reads))
 
     def testTwoFiles(self):
         """

--- a/test/test_fasta_ss.py
+++ b/test/test_fasta_ss.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .mocking import mockOpen, File
 
-from dark.reads import SSAARead
+from dark.reads import SSAARead, ReadFilter
 from dark.fasta_ss import SSFastaReads
 
 
@@ -225,3 +225,18 @@ class TestSSFastaReads(TestCase):
                     SSAARead('id2', 'CAGT', 'eeee'),
                 ],
                 list(reads))
+
+    def testDirectFiltering(self):
+        """
+        It must be possible to directly use a ReadFilter to filter the reads
+        that end up in an SSFastaReads instance (from the reads that are read
+        from the input file).
+        """
+        data = '\n'.join(['>one', 'atat', '>one', 'hhhh',
+                          '>two', 'atcg', '>two', 'eeee'])
+        readFilter = ReadFilter(head=1)
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = SSFastaReads(data, readClass=SSAARead,
+                                 filterFunc=readFilter.filter)
+            self.assertEqual([SSAARead('one', 'atat', 'hhhh')], list(reads))

--- a/test/test_fastq.py
+++ b/test/test_fastq.py
@@ -1,6 +1,6 @@
 from six.moves import builtins
 
-from dark.reads import AARead, DNARead, RNARead
+from dark.reads import AARead, DNARead, RNARead, ReadFilter
 from dark.fastq import FastqReads
 
 from unittest import TestCase
@@ -126,3 +126,18 @@ class TestFastqReads(TestCase):
                     DNARead('id2', 'CAGT', '!!!!'),
                 ],
                 list(reads))
+
+    def testDirectFiltering(self):
+        """
+        It must be possible to directly use a ReadFilter to filter the reads
+        that end up in a FastqReads instance (from the reads that are read
+        from the input file).
+        """
+        data = '\n'.join(['@one', 'atat', '+', '3333',
+                          '@two', 'atcg', '+', '4444'])
+        readFilter = ReadFilter(head=1)
+        mockOpener = mockOpen(read_data=data)
+        with patch.object(builtins, 'open', mockOpener):
+            reads = FastqReads(data, readClass=AARead,
+                               filterFunc=readFilter.filter)
+            self.assertEqual([DNARead('one', 'atat', '3333')], list(reads))


### PR DESCRIPTION
Change Reads so it can accept a filterFunc argument to filter reads as they are added to the class or yielded in Reads.iter by a subclass. Change FastaReads, FastqReads, and SSFastaReads to accept the filterFunc arg. Change filter-fasta.py to use a ReadFilter when making its Reads instance.

Fixes #478.