### PR TITLE
Print either FASTQ or FASTA in noninteractive-alignment-panel.py depending on what read class is in use.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.88',
+      version='1.0.89',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
Fixes #483.
