### PR TITLE
Fixed small bug in filter-fasta.py calling len on a reads instance

### DIFF
--- a/bin/filter-fasta.py
+++ b/bin/filter-fasta.py
@@ -145,9 +145,12 @@ if __name__ == '__main__':
 
     write = sys.stdout.write
     kept = 0
-    count = 0
-    for count, read in enumerate(reads):
+    for read in reads:
         kept += 1
         write(read.toString(format_=saveAs))
 
-    print('Read %d sequences, kept %d.' % (count, kept), file=sys.stderr)
+    total = reads.unfilteredLength()
+
+    print('Read %d sequences, kept %d (%.2f%%).' %
+          (total, kept, 0.0 if total == 0 else kept / total),
+          file=sys.stderr)

--- a/bin/filter-fasta.py
+++ b/bin/filter-fasta.py
@@ -145,8 +145,9 @@ if __name__ == '__main__':
 
     write = sys.stdout.write
     kept = 0
-    for read in reads:
+    count = 0
+    for count, read in enumerate(reads):
         kept += 1
         write(read.toString(format_=saveAs))
 
-    print('Read %d sequences, kept %d.' % (len(reads), kept), file=sys.stderr)
+    print('Read %d sequences, kept %d.' % (count, kept), file=sys.stderr)

--- a/bin/filter-fasta.py
+++ b/bin/filter-fasta.py
@@ -151,6 +151,6 @@ if __name__ == '__main__':
 
     total = reads.unfilteredLength()
 
-    print('Read %d sequences, kept %d (%.2f%%).' %
-          (total, kept, 0.0 if total == 0 else kept / total),
-          file=sys.stderr)
+    print('Read %d sequence%s, kept %d (%.2f%%).' %
+          (total, '' if total == 1 else 's', kept,
+           0.0 if total == 0 else kept / total), file=sys.stderr)

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -1038,6 +1038,7 @@ class Reads(object):
         must count the reads yourself as you iterate it.
 
         @raises RuntimeError: If C{self} has not been fully iterated.
+        @return: The C{int} number of reads in C{self}.
         """
         if self._iterated:
             return self._unfilteredLength

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.89',
+      version='1.0.90',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',


### PR DESCRIPTION
It's no longer possible to call `len()` on a reads instance.  That was never 100% reliable in any case - you always had to enumerate the reads instance before you could get the length.

Fixes #485.
