### PR TITLE
Removed checkAlphabet from FastaReads etc.

### DIFF
--- a/bin/noninteractive-alignment-panel.py
+++ b/bin/noninteractive-alignment-panel.py
@@ -45,7 +45,6 @@ def parseColors(colors, args):
     @return: A C{dict} whose keys are colors and whose values are sets of
         read ids.
     """
-    checkAlphabet = args.checkAlphabet
     result = defaultdict(set)
     for colorInfo in colors:
         readIds = colorInfo.split()
@@ -54,7 +53,7 @@ def parseColors(colors, args):
             if os.path.isfile(readId):
                 filename = readId
                 if args.fasta:
-                    reads = FastaReads(filename, checkAlphabet=checkAlphabet)
+                    reads = FastaReads(filename)
                 else:
                     reads = FastqReads(filename)
                 for read in reads:
@@ -244,12 +243,6 @@ if __name__ == '__main__':
         help='The base of the logarithm to use if logLinearXAxis is True')
 
     parser.add_argument(
-        '--checkAlphabet', type=int, default=None,
-        help=('An integer, indicating how many bases or amino acids at the '
-              'start of sequences should have their alphabet checked. If not '
-              'specified, all bases are checked.'))
-
-    parser.add_argument(
         '--showFeatures', default=False, action='store_true',
         help=('If specified, look up features for the individual images in '
               'the alignment panel.'))
@@ -272,13 +265,8 @@ if __name__ == '__main__':
     # TODO: Add a --readClass command-line option in case we want to
     # process FASTA containing AA sequences.
     if args.fasta:
-        reads = FastaReads(list(chain.from_iterable(args.fasta)),
-                           checkAlphabet=args.checkAlphabet)
+        reads = FastaReads(list(chain.from_iterable(args.fasta)))
     else:
-        if args.checkAlphabet is not None:
-            print('--checkAlphabet is currently not supported for FASTQ reads',
-                  file=sys.stderr)
-            sys.exit(1)
         reads = FastqReads(list(chain.from_iterable(args.fastq)))
 
     if args.matcher == 'blast':

--- a/dark/diamond/alignments.py
+++ b/dark/diamond/alignments.py
@@ -125,7 +125,7 @@ class DiamondReadsAlignments(ReadsAlignments):
         if self._subjectTitleToSubject is None:
             titles = {}
             for read in FastaReads(self._databaseFilename,
-                                   readClass=AAReadWithX, checkAlphabet=0):
+                                   readClass=AAReadWithX):
                 titles[read.id] = read
             self._subjectTitleToSubject = titles
 

--- a/dark/fasta.py
+++ b/dark/fasta.py
@@ -86,17 +86,12 @@ class FastaReads(Reads):
         C{list} of C{str} file names and/or file handles. Each file or file
         handle must contain sequences in FASTA format.
     @param readClass: The class of read that should be yielded by iter.
-    @param checkAlphabet: An C{int} or C{None}. If C{None}, alphabet checking
-        will be done on all reads. If an C{int}, only that many reads will be
-        checked. (Pass zero to have no checks done.)
     @param upperCase: If C{True}, read sequences will be converted to upper
         case.
     """
-    def __init__(self, _files, readClass=DNARead, checkAlphabet=None,
-                 upperCase=False):
+    def __init__(self, _files, readClass=DNARead, upperCase=False):
         self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
-        self._checkAlphabet = checkAlphabet
         # TODO: It would be better if upperCase were an argument that could
         # be passed to Reads.__init__ and that could do the uppercasing in
         # its add method (as opposed to using it below in our iter method).
@@ -115,7 +110,6 @@ class FastaReads(Reads):
         Iterate over the sequences in the files in self.files_, yielding each
         as an instance of the desired read class.
         """
-        checkAlphabet = self._checkAlphabet
         count = 0
         for _file in self._files:
             with asHandle(_file) as fp:
@@ -125,8 +119,6 @@ class FastaReads(Reads):
                                                str(seq.seq.upper()))
                     else:
                         read = self._readClass(seq.description, str(seq.seq))
-                    if checkAlphabet is None or count < checkAlphabet:
-                        read.checkAlphabet(count=None)
                     yield read
                     count += 1
 
@@ -171,7 +163,6 @@ def combineReads(filename, sequences, readClass=DNARead,
             if upperCase:
                 sequence = sequence.upper()
             read = readClass(readId, sequence)
-            read.checkAlphabet()
             reads.add(read)
 
     return reads

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -28,17 +28,12 @@ class SSFastaReads(Reads):
         handle must contain sequences in PDB FASTA format (see above).
     @param readClass: The class of read that should be yielded by iter. This
         must accept 3 C{str} arguments: an id, the sequence, the structure.
-    @param checkAlphabet: An C{int} or C{None}. If C{None}, alphabet checking
-        will be done on all reads. If an C{int}, only that many reads will be
-        checked. (Pass zero to have no checks done.)
     @param upperCase: If C{True}, both read and structure sequences will be
         converted to upper case.
     """
-    def __init__(self, _files, readClass=SSAARead, checkAlphabet=None,
-                 upperCase=False):
+    def __init__(self, _files, readClass=SSAARead, upperCase=False):
         self._files = _files if isinstance(_files, (list, tuple)) else [_files]
         self._readClass = readClass
-        self._checkAlphabet = checkAlphabet
         self._upperCase = upperCase
         if PY3:
             super().__init__()
@@ -54,9 +49,7 @@ class SSFastaReads(Reads):
             if any sequence has a different length than its predicted
             secondary structure.
         """
-        checkAlphabet = self._checkAlphabet
         upperCase = self._upperCase
-        count = 0
         for _file in self._files:
             with asHandle(_file) as fp:
                 records = SeqIO.parse(fp, 'fasta')
@@ -65,8 +58,6 @@ class SSFastaReads(Reads):
                         record = next(records)
                     except StopIteration:
                         break
-
-                    count += 1
 
                     try:
                         structureRecord = next(records)
@@ -91,8 +82,5 @@ class SSFastaReads(Reads):
                         read = self._readClass(record.description,
                                                str(record.seq),
                                                str(structureRecord.seq))
-
-                    if checkAlphabet is None or count < checkAlphabet:
-                        read.checkAlphabet(count=None)
 
                     yield read

--- a/dark/proteins.py
+++ b/dark/proteins.py
@@ -59,8 +59,7 @@ class VirusSampleFASTA(object):
             reads = Reads()
             for protein in self._proteinGrouper.virusTitles[
                     virusTitle][sampleName]['proteins']:
-                for read in FastaReads(protein['fastaFilename'],
-                                       checkAlphabet=0):
+                for read in FastaReads(protein['fastaFilename']):
                     reads.add(read)
             saveFilename = join(
                 protein['outDir'],

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -1284,12 +1284,6 @@ def addFASTACommandLineOptions(parser):
         '--readClass', default='DNARead', choices=readClassNameToClass,
         help='If specified, give the type of the reads in the input.')
 
-    parser.add_argument(
-        '--checkAlphabet', type=int, default=None,
-        help=('An integer, indicating how many bases or amino acids at the '
-              'start of sequences should have their alphabet checked. If not '
-              'specified, all bases are checked.'))
-
     # A mutually exclusive group for either --fasta, --fastq, or --fasta-ss
     group = parser.add_mutually_exclusive_group()
 
@@ -1326,12 +1320,10 @@ def parseFASTACommandLineOptions(args):
 
     if args.fasta:
         from dark.fasta import FastaReads
-        return FastaReads(args.fastaFile, readClass=readClass,
-                          checkAlphabet=args.checkAlphabet)
+        return FastaReads(args.fastaFile, readClass=readClass)
     elif args.fastq:
         from dark.fastq import FastqReads
         return FastqReads(args.fastaFile, readClass=readClass)
     else:
         from dark.fasta_ss import SSFastaReads
-        return SSFastaReads(args.fastaFile, readClass=readClass,
-                            checkAlphabet=args.checkAlphabet)
+        return SSFastaReads(args.fastaFile, readClass=readClass)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.100',
+      version='1.0.101',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_fasta.py
+++ b/test/test_fasta.py
@@ -1,4 +1,3 @@
-import six
 from six.moves import builtins
 from six import StringIO
 from unittest import TestCase
@@ -341,76 +340,6 @@ class TestFastaReads(TestCase):
         with patch.object(builtins, 'open', mockOpener):
             reads = list(FastaReads('filename.fasta', RNARead))
             self.assertTrue(isinstance(reads[0], RNARead))
-
-    def testAlphabetIsCheckedAndRaisesValueErrorOnFirstRead(self):
-        """
-        The default behavior of a FastaReads instance is to check to ensure
-        its sequences have the correct alphabet and to raise ValueError if not.
-        A non-alphabetic character in the first read must be detected.
-        """
-        data = '\n'.join([
-            '>one',
-            'at-at',
-        ])
-        error = ("^Read alphabet \('-AT'\) is not a subset of expected "
-                 "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
-                 "AARead\.$")
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            six.assertRaisesRegex(self, ValueError, error, list,
-                                  FastaReads(data, AARead))
-
-    def testAlphabetIsCheckedAndRaisesValueErrorOnSecondRead(self):
-        """
-        The default behavior of a FastaReads instance is to check to ensure
-        its sequences have the correct alphabet and to raise ValueError if not.
-        A non-alphabetic character in the second read must be detected.
-        """
-        data = '\n'.join([
-            '>one',
-            'atat',
-            '>two',
-            'at-at',
-        ])
-        mockOpener = mockOpen(read_data=data)
-        error = ("^Read alphabet \('-AT'\) is not a subset of expected "
-                 "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
-                 "AARead\.$")
-        with patch.object(builtins, 'open', mockOpener):
-            six.assertRaisesRegex(self, ValueError, error, list,
-                                  FastaReads(data, AARead))
-
-    def testDisableAlphabetChecking(self):
-        """
-        It must be possible to have a FastaReads instance not do alphabet
-        checking, if requested (by passing checkAlphabet=0).
-        """
-        data = '\n'.join([
-            '>one',
-            'at-at',
-        ])
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            self.assertEqual(1, len(list(FastaReads(data, AARead,
-                                                    checkAlphabet=0))))
-
-    def testOnlyCheckSomeAlphabets(self):
-        """
-        It must be possible to have the alphabets of only a certain number of
-        reads checked. A non-alphabetic character in a later read must not
-        stop that read from being processed.
-        """
-        data = '\n'.join([
-            '>one',
-            'atat',
-            '>two',
-            'at-at',
-        ])
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            reads = list(FastaReads(data, AARead, checkAlphabet=1))
-            self.assertEqual(2, len(reads))
-            self.assertEqual('at-at', reads[1].sequence)
 
     def testConvertLowerToUpperCaseIfSpecifiedAARead(self):
         """

--- a/test/test_fasta_ss.py
+++ b/test/test_fasta_ss.py
@@ -113,64 +113,8 @@ class TestSSFastaReads(TestCase):
         data = '\n'.join(['>seq1', 'RRRR', '>str1', 'HHHH'])
         mockOpener = mockOpen(read_data=data)
         with patch.object(builtins, 'open', mockOpener):
-            reads = list(SSFastaReads(data, readClass=ReadClass,
-                                      checkAlphabet=0))
+            reads = list(SSFastaReads(data, readClass=ReadClass))
             self.assertTrue(isinstance(reads[0], ReadClass))
-
-    def testAlphabetIsCheckedAndRaisesValueErrorOnFirstRead(self):
-        """
-        The default behavior of a SSFastaReads instance is to check to ensure
-        its sequences have the correct alphabet and to raise ValueError if not.
-        A non-alphabetic character in the first read must be detected.
-        """
-        data = '\n'.join(['>seq1', 'at-at', '>str1', 'HH-HH'])
-        error = ("^Read alphabet \('-AT'\) is not a subset of expected "
-                 "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
-                 "SSAARead\.$")
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            six.assertRaisesRegex(self, ValueError, error, list,
-                                  SSFastaReads(data))
-
-    def testAlphabetIsCheckedAndRaisesValueErrorOnSecondRead(self):
-        """
-        The default behavior of a SSFastaReads instance is to check to ensure
-        its sequences have the correct alphabet and to raise ValueError if not.
-        A non-alphabetic character in the second read must be detected.
-        """
-        data = '\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
-                          '>seq2', 'a-at', '>str2', 'hhhh'])
-        error = ("^Read alphabet \('-AT'\) is not a subset of expected "
-                 "alphabet \('ACDEFGHIKLMNPQRSTVWY'\) for read class "
-                 "SSAARead\.$")
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            six.assertRaisesRegex(self, ValueError, error, list,
-                                  SSFastaReads(data))
-
-    def testDisableAlphabetChecking(self):
-        """
-        It must be possible to have a SSFastaReads instance not do alphabet
-        checking, if requested (by passing checkAlphabet=0).
-        """
-        data = '\n'.join(['>seq1', 'rr-rr', '>str1', 'hh-hh'])
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            self.assertEqual(1, len(list(SSFastaReads(data, checkAlphabet=0))))
-
-    def testOnlyCheckSomeAlphabets(self):
-        """
-        It must be possible to have the alphabets of only a certain number of
-        reads checked. A non-alphabetic character in a later read must not
-        stop that read from being processed.
-        """
-        data = '\n'.join(['>seq1', 'rrrr', '>str1', 'hhhh',
-                          '>seq2', 'r-rr', '>str2', 'h-hh'])
-        mockOpener = mockOpen(read_data=data)
-        with patch.object(builtins, 'open', mockOpener):
-            reads = list(SSFastaReads(data, checkAlphabet=1))
-            self.assertEqual(2, len(reads))
-            self.assertEqual('r-rr', reads[1].sequence)
 
     def testConvertLowerToUpperCaseIfSpecified(self):
         """

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -437,8 +437,8 @@ class TestRead(TestCase):
 
     def testCheckAlphabetwithReadMustBePermissive(self):
         """
-        The checkAlphabet function must be permissive if a dark.Read is
-        passed.
+        The checkAlphabet function must return the expected alphabet if a
+        dark.Read is passed.
         """
         read = Read('id', 'ARSTGATGCASASASASASAS')
         self.assertEqual(set('ACGSRT'), read.checkAlphabet())


### PR DESCRIPTION
Removed checkAlphabet from FastaReads and SSFastaReads. Removed --checkAlphabet as an option in noninteractive-alignment-panel.py and from the general FASTA command line options in reads.py

Fixes #497