### PR TITLE
Added --proteinFastaFilename and --minProteinFraction args to proteins-to-viruses.py

### DIFF
--- a/bin/proteins-to-viruses.py
+++ b/bin/proteins-to-viruses.py
@@ -89,10 +89,28 @@ if __name__ == '__main__':
               'noninteractive-alignment-panel.py when it created the '
               'summary-proteins files given on output.'))
 
+    parser.add_argument(
+        '--proteinFastaFilename', '--pff',
+        help=('An (optional) filename giving the name of the FASTA file '
+              'with the protein AA sequences with their associated viruses in '
+              'square brackets. This is the format used by NCBI for the viral '
+              'protein files. If given, the contents of this file will be '
+              'used to determine how many proteins each matched virus has. '
+              'This makes it much easier to spot significant matches (as '
+              'opposed to those where, say, just one protein from a virus is '
+              'matched).'))
+
+    parser.add_argument(
+        '--minProteinFraction', type=float, default=0.0,
+        help=('The minimum fraction of proteins in a virus that must be '
+              'matched by at least one sample in order for that virus to '
+              'be displayed.'))
+
     args = parser.parse_args()
 
     grouper = ProteinGrouper(sampleNameRegex=args.sampleNameRegex,
-                             format_=args.format)
+                             format_=args.format,
+                             proteinFastaFilename=args.proteinFastaFilename)
 
     if args.filenames:
         filenames = args.filenames
@@ -104,6 +122,7 @@ if __name__ == '__main__':
             grouper.addFile(filename, fp)
 
     if args.html:
-        print(grouper.toHTML(args.virusPanelFilename))
+        print(grouper.toHTML(args.virusPanelFilename,
+                             minProteinFraction=args.minProteinFraction))
     else:
         print(grouper.toStr())

--- a/dark/proteins.py
+++ b/dark/proteins.py
@@ -260,7 +260,6 @@ class ProteinGrouper(object):
         @raise ValueError: If information for a virus/protein/sample
             combination is given more than once.
         """
-
         if self._sampleNameRegex:
             match = self._sampleNameRegex.search(filename)
             if match:

--- a/dark/proteins.py
+++ b/dark/proteins.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 from six.moves.urllib.parse import quote
 import numpy as np
 from textwrap import fill
+from collections import Counter
 
 try:
     import matplotlib.pyplot as plt
@@ -22,6 +23,75 @@ from dark.fasta import FastaReads
 from dark.fastq import FastqReads
 from dark.html import NCBISequenceLinkURL
 from dark.reads import Reads
+
+# The following regex is deliberately greedy (using .*) to consume the
+# whole protein title before backtracking to find the last [virus title]
+# section. That way, it will match just the last [virus title] in a
+# protein. This avoids situations in which two [...] delimited substrings
+# are present in a protein name (in which case we just want the last).
+# E.g., the following is a complete protein name:
+#
+#   gi|19919894|ref|NP_612577.1| Enzymatic polyprotein [Contains: Aspartic
+#   protease; Endonuclease; Reverse transcriptase] [Carnation etched ring
+#   virus]
+#
+# Unfortunately the regex doesn't find the virus title when the protein
+# title has nested [...] sections, as in this example:
+#
+#   gi|224808893|ref|YP_002643049.1| replication-associated protein [Tomato
+#   leaf curl Nigeria virus-[Nigeria:2006]]
+#
+# I decided not to worry about nested [...] sections (there are only 2
+# instances that I know of).
+_VIRUS_RE = re.compile('^(.*)\[([^\]]+)\]$')
+
+# The virus title assigned to proteins whose title strings cannot be parsed
+# for a virus title (see previous comment).  Do not use '<', '>' or any
+# other HTML special chars in the following.
+_NO_VIRUS_TITLE = '[no virus name found in protein title]'
+
+
+def splitTitles(titles):
+    """
+    Split a title like "Protein name [virus name]" into two pieces using
+    the final square brackets to delimit the virus name.
+
+    @param titles: A C{str} protein and virus title.
+    @return: A 2-C{tuple} giving the C{str} protein title and C{str} virus
+        title. If C{titles} cannot be split on square brackets, it is
+        returned as the first tuple element, followed by _NO_VIRUS_TITLE.
+    """
+    match = _VIRUS_RE.match(titles)
+    if match:
+        proteinTitle = match.group(1).strip()
+        virusTitle = match.group(2).strip()
+    else:
+        proteinTitle = titles
+        virusTitle = _NO_VIRUS_TITLE
+
+    return proteinTitle, virusTitle
+
+
+def getVirusProteinCounts(filename):
+    """
+    Get the number of proteins for each virus in C{filename}.
+
+    @param filename: Either C{None} or a C{str} FASTA file name. If C{None}
+        an empty C{Counter} is returned. If a FASTA file name is given, its
+        sequence ids should have the format used in the NCBI viral protein
+        file, in which the protein name is followed by the virus name in
+        square brackets.
+    @return: A C{Counter} keyed by C{str} virus name, whose values are C{int}s
+        with the count of the number of proteins for the virus.
+    """
+    result = Counter()
+    if filename:
+        for protein in FastaReads(filename):
+            _, virusTitle = splitTitles(protein.id)
+            if virusTitle != _NO_VIRUS_TITLE:
+                result[virusTitle] += 1
+
+    return result
 
 
 class VirusSampleFiles(object):
@@ -66,12 +136,12 @@ class VirusSampleFiles(object):
             return self._readsFilenames[(virusIndex, sampleIndex)]
         except KeyError:
             reads = Reads()
-            for protein in self._proteinGrouper.virusTitles[
-                    virusTitle][sampleName]['proteins']:
-                for read in self._readsClass(protein['readsFilename']):
+            for proteinMatch in self._proteinGrouper.virusTitles[
+                    virusTitle][sampleName]['proteins'].values():
+                for read in self._readsClass(proteinMatch['readsFilename']):
                     reads.add(read)
             saveFilename = join(
-                protein['outDir'],
+                proteinMatch['outDir'],
                 'virus-%d-sample-%d.%s' % (virusIndex, sampleIndex,
                                            self._format))
             reads.filter(removeDuplicates=True)
@@ -117,38 +187,18 @@ class ProteinGrouper(object):
         should be used as the sample name.
     @param format_: A C{str}, either 'fasta' or 'fastq' indicating the format
         of the files containing the reads matching proteins.
+    @param proteinFastaFilename: If not C{None}, a C{str} filename giving the
+        name of the FASTA file with the protein AA sequences with their
+        associated viruses in square brackets. This is the format used by NCBI
+        for the viral protein files. If given, the contents of this file will
+        be used to determine how many proteins each matched virus has.
     @raise ValueError: If C{format_} is unknown.
     """
 
-    # The following regex is deliberately greedy (using .*) to consume the
-    # whole protein title before backtracking to find the last [virus title]
-    # section. That way, it will match just the last [virus title] in a
-    # protein. This avoids situations in which two [...] delimited substrings
-    # are present in a protein name (in which case we just want the last).
-    # E.g., the following is a complete protein name:
-    #
-    #   gi|19919894|ref|NP_612577.1| Enzymatic polyprotein [Contains: Aspartic
-    #   protease; Endonuclease; Reverse transcriptase] [Carnation etched ring
-    #   virus]
-    #
-    # Unfortunately the regex doesn't find the virus title when the protein
-    # title has nested [...] sections, as in this example:
-    #
-    #   gi|224808893|ref|YP_002643049.1| replication-associated protein [Tomato
-    #   leaf curl Nigeria virus-[Nigeria:2006]]
-    #
-    # I decided not to worry about nested [...] sections (there are only 2
-    # instances that I know of).
-    VIRUS_RE = re.compile('^(.*)\[([^\]]+)\]$')
-
-    # The virus title assigned to proteins whose title strings cannot be parsed
-    # for a virus title (see previous comment).  Do not use '<', '>' or any
-    # other HTML special chars in the following.
-    NO_VIRUS_TITLE = '[no virus name found in protein title]'
-
     VIRALZONE = 'http://viralzone.expasy.org/cgi-bin/viralzone/search?query='
 
-    def __init__(self, assetDir='out', sampleNameRegex=None, format_='fasta'):
+    def __init__(self, assetDir='out', sampleNameRegex=None, format_='fasta',
+                 proteinFastaFilename=None):
         self._assetDir = assetDir
         self._sampleNameRegex = (re.compile(sampleNameRegex) if sampleNameRegex
                                  else None)
@@ -156,6 +206,9 @@ class ProteinGrouper(object):
             self._format = format_
         else:
             raise ValueError("format_ must be either 'fasta' or 'fastq'.")
+
+        self._virusProteinCount = getVirusProteinCounts(proteinFastaFilename)
+
         # virusTitles will be a dict of dicts of dicts. The first two keys
         # will be a virus title and a sample name. The final dict will
         # contain 'proteins' (a list of dicts) and 'uniqueReadCount' (an int).
@@ -172,9 +225,31 @@ class ProteinGrouper(object):
         @return: A C{str} title.
         """
         return (
-            '%d virus%s found in %d sample%s' %
-            (len(self.virusTitles), '' if len(self.virusTitles) == 1 else 'es',
-             len(self.sampleNames), '' if len(self.sampleNames) == 1 else 's'))
+            'Overall, proteins from %d virus%s were found in %d sample%s.' %
+            (len(self.virusTitles),
+             '' if len(self.virusTitles) == 1 else 'es',
+             len(self.sampleNames),
+             '' if len(self.sampleNames) == 1 else 's'))
+
+    def maxProteinFraction(self, virusTitle):
+        """
+        Get the fraction of a virus' proteins matched by any sample that
+        matches the virus.
+
+        @param virusTitle: A C{str} virus title.
+        @return: The C{float} maximum fraction of a virus' proteins that is
+            matched by any sample. If the number of proteins for the virus is
+            unknown, return 1.0 (i.e., assume all proteins are matched).
+        """
+
+        proteinCount = self._virusProteinCount[virusTitle]
+        if proteinCount:
+            maxMatches = max(
+                len(sample['proteins'])
+                for sample in self.virusTitles[virusTitle].values())
+            return maxMatches / proteinCount
+        else:
+            return 1.0
 
     def addFile(self, filename, fp):
         """
@@ -182,6 +257,8 @@ class ProteinGrouper(object):
 
         @param filename: A C{str} file name.
         @param fp: An open file pointer to read the file's data from.
+        @raise ValueError: If information for a virus/protein/sample
+            combination is given more than once.
         """
 
         if self._sampleNameRegex:
@@ -202,24 +279,27 @@ class ProteinGrouper(object):
             (coverage, medianScore, bestScore, readCount, hspCount,
              proteinLength, titles) = proteinLine.split(None, 6)
 
-            match = self.VIRUS_RE.match(titles)
-            if match:
-                proteinTitle = match.group(1).strip()
-                virusTitle = match.group(2)
-            else:
-                proteinTitle = titles
-                virusTitle = self.NO_VIRUS_TITLE
+            proteinTitle, virusTitle = splitTitles(titles)
 
             if virusTitle not in self.virusTitles:
                 self.virusTitles[virusTitle] = {}
 
             if sampleName not in self.virusTitles[virusTitle]:
                 self.virusTitles[virusTitle][sampleName] = {
-                    'proteins': [],
+                    'proteins': {},
                     'uniqueReadCount': None,
                 }
 
-            self.virusTitles[virusTitle][sampleName]['proteins'].append({
+            proteins = self.virusTitles[virusTitle][sampleName]['proteins']
+
+            # We should only receive one line of information for a given
+            # virus/sample/protein combination.
+            if proteinTitle in proteins:
+                raise ValueError(
+                    'Protein %r already seen for virus %r sample %r.' %
+                    (proteinTitle, virusTitle, sampleName))
+
+            proteins[proteinTitle] = {
                 'bestScore': float(bestScore),
                 'bluePlotFilename': join(outDir, '%d.png' % index),
                 'coverage': float(coverage),
@@ -232,7 +312,7 @@ class ProteinGrouper(object):
                 'proteinTitle': proteinTitle,
                 'proteinURL': NCBISequenceLinkURL(proteinTitle),
                 'readCount': int(readCount),
-            })
+            }
 
     def _computeUniqueReadCounts(self):
         """
@@ -256,7 +336,6 @@ class ProteinGrouper(object):
         # unique (de-duplicated) read count, since that is only computed
         # when we are making combined FASTA files of reads matching a
         # virus.
-        titleGetter = itemgetter('proteinTitle')
         readCountGetter = itemgetter('readCount')
         result = []
         append = result.append
@@ -273,45 +352,51 @@ class ProteinGrouper(object):
             for sampleName in sorted(samples):
                 proteins = samples[sampleName]['proteins']
                 proteinCount = len(proteins)
-                totalReads = sum(readCountGetter(p) for p in proteins)
+                totalReads = sum(readCountGetter(p) for p in proteins.values())
                 append('  %s (%d protein%s, %d read%s)' %
                        (sampleName,
                         proteinCount, '' if proteinCount == 1 else 's',
                         totalReads, '' if totalReads == 1 else 's'))
-                proteins.sort(key=titleGetter)
-                for proteinMatch in proteins:
+                for proteinTitle in sorted(proteins):
                     append(
                         '    %(coverage).2f\t%(medianScore).2f\t'
                         '%(bestScore).2f\t%(readCount)4d\t%(hspCount)4d\t'
                         '%(index)3d\t%(proteinTitle)s'
-                        % proteinMatch)
+                        % proteins[proteinTitle])
             append('')
 
         return '\n'.join(result)
 
-    def toHTML(self, virusPanelFilename=None):
+    def toHTML(self, virusPanelFilename=None, minProteinFraction=0.0):
         """
         Produce an HTML string representation of the virus summary.
 
         @param virusPanelFilename: If not C{None}, a C{str} filename to write
             a virus panel PNG image to.
+        @param minProteinFraction: The C{float} minimum fraction of proteins
+            in a virus that must be matched by at least one sample in order for
+            that virus to be displayed.
         @return: An HTML C{str} suitable for printing.
         """
+        highlightSymbol = '&starf;'
         self._computeUniqueReadCounts()
 
         if virusPanelFilename:
             self.virusPanel(virusPanelFilename)
 
-        titleGetter = itemgetter('proteinTitle')
-        virusTitles = sorted(self.virusTitles)
+        virusTitles = sorted(
+            virusTitle for virusTitle in self.virusTitles
+            if self.maxProteinFraction(virusTitle) >= minProteinFraction)
+        nVirusTitles = len(virusTitles)
         sampleNames = sorted(self.sampleNames)
 
         result = [
             '<html>',
             '<head>',
             '<title>',
-            self._title(),
+            'Summary of viruses',
             '</title>',
+            '<meta charset="UTF-8">',
             '</head>',
             '<body>',
             '<style>',
@@ -320,11 +405,35 @@ class ProteinGrouper(object):
                 margin-left: 2%;
                 margin-right: 2%;
             }
+            hr {
+                display: block;
+                margin-top: 0.5em;
+                margin-bottom: 0.5em;
+                margin-left: auto;
+                margin-right: auto;
+                border-style: inset;
+                border-width: 1px;
+            }
+            .significant {
+                color: red;
+                margin-right: 2px;
+            }
             .sample {
                 margin-bottom: 2px;
             }
+            .indented {
+                margin-left: 2em;
+            }
             .sample-name {
-                color: red;
+                font-size: 125%;
+                font-weight: bold;
+            }
+            .virus-title {
+                font-size: 125%;
+                font-weight: bold;
+            }
+            .index-title {
+                font-weight: bold;
             }
             .index {
                 font-size: small;
@@ -346,7 +455,7 @@ class ProteinGrouper(object):
 
         proteinFieldsDescription = (
             '<p>',
-            'In the bullet point protein lists below, there are eight fields:',
+            'In all bullet point protein lists below, there are eight fields:',
             '<ol>',
             '<li>Coverage fraction.</li>',
             '<li>Median bit score.</li>',
@@ -362,7 +471,36 @@ class ProteinGrouper(object):
 
         append = result.append
 
-        append('<h1>%s</h1>' % self._title())
+        append('<h1>Summary of viruses</h1>')
+        append('<p>')
+        append(self._title())
+
+        if self._virusProteinCount:
+            percent = minProteinFraction * 100.0
+            if nVirusTitles < len(self.virusTitles):
+                if nVirusTitles == 1:
+                    append('Virus protein fraction filtering has been '
+                           'applied, so information on only 1 virus is '
+                           'displayed. This is the only virus for which at '
+                           'least one sample matches at least %.2f%% of the '
+                           'viral proteins.' % percent)
+                else:
+                    append('Virus protein fraction filtering has been '
+                           'applied, so information on only %d viruses is '
+                           'displayed. These are the only viruses for which '
+                           'at least one sample matches at least %.2f%% of '
+                           'the viral proteins.' % (nVirusTitles, percent))
+            else:
+                append('Virus protein fraction filtering has been applied, '
+                       'but all viruses have at least %.2f%% of their '
+                       'proteins matched by at least one sample.')
+
+            append('Samples that match a virus (and viruses with a matching '
+                   'sample) with at least this protein fraction are '
+                   'highlighted using <span class="significant">%s</span>.' %
+                   highlightSymbol)
+
+        append('</p>')
 
         if virusPanelFilename:
             append('<p>')
@@ -372,59 +510,76 @@ class ProteinGrouper(object):
                    'read count.')
             append('</p>')
 
+        result.extend(proteinFieldsDescription)
+
         # Write a linked table of contents by virus.
-        append('<h2>Virus index</h2>')
-        append('<p class="index">')
+        append('<p><span class="index-title">Virus index:</span>')
+        append('<span class="index">')
         for virusTitle in virusTitles:
             append('<a href="#virus-%s">%s</a>' % (virusTitle, virusTitle))
             append('&middot;')
-        # Get rid of final middle dot.
+        # Get rid of final middle dot and add a period.
         result.pop()
-        append('</p>')
+        result[-1] += '.'
+        append('</span></p>')
 
         # Write a linked table of contents by sample.
-        append('<h2>Sample index</h2>')
-        append('<p class="index">')
+        append('<p><span class="index-title">Sample index:</span>')
+        append('<span class="index">')
         for sampleName in sampleNames:
             append('<a href="#sample-%s">%s</a>' % (sampleName, sampleName))
             append('&middot;')
-        # Get rid of final middle dot.
+        # Get rid of final middle dot and add a period.
         result.pop()
-        append('</p>')
+        result[-1] += '.'
+        append('</span></p>')
 
         # Write all viruses (with samples (with proteins)).
+        append('<hr>')
         append('<h1>Viruses by sample</h1>')
-        result.extend(proteinFieldsDescription)
 
         for virusTitle in virusTitles:
             samples = self.virusTitles[virusTitle]
             sampleCount = len(samples)
+            virusProteinCount = self._virusProteinCount[virusTitle]
             append(
-                '<a id="virus-%s">'
-                '<h2 class="virus"><span class="virus-title">%s</span> '
-                '(in %d sample%s, <a href="%s%s">viralzone</a>)</h2>' %
-                (virusTitle, virusTitle, sampleCount,
-                 '' if sampleCount == 1 else 's',
-                 self.VIRALZONE, quote(virusTitle)))
+                '<a id="virus-%s"></a>'
+                '<span class="virus-title"><a href="%s%s">%s</a></span>'
+                '%s, was matched by %d sample%s:' %
+                (virusTitle, self.VIRALZONE, quote(virusTitle),
+                 virusTitle,
+                 ((' (with %d protein%s)' %
+                   (virusProteinCount, '' if virusProteinCount == 1 else 's'))
+                  if virusProteinCount else ''),
+                 sampleCount,
+                 '' if sampleCount == 1 else 's'))
             for sampleName in sorted(samples):
                 readsFileName = self.virusSampleFiles.lookup(virusTitle,
                                                              sampleName)
                 proteins = samples[sampleName]['proteins']
                 proteinCount = len(proteins)
                 uniqueReadCount = samples[sampleName]['uniqueReadCount']
+                if virusProteinCount and (
+                        proteinCount / virusProteinCount >=
+                        minProteinFraction):
+                    highlight = ('<span class="significant">%s</span>' %
+                                 highlightSymbol)
+                else:
+                    highlight = ''
+
                 append(
-                    '<p class=sample>'
-                    '<span class="sample-name">%s</span> '
+                    '<p class="sample indented">'
+                    '%sSample <a href="#sample-%s">%s</a> '
                     '(%d protein%s, <a href="%s">%d read%s</a>, '
-                    '<a href="%s">panel</a>)' %
-                    (sampleName,
+                    '<a href="%s">panel</a>):</p>' %
+                    (highlight, sampleName, sampleName,
                      proteinCount, '' if proteinCount == 1 else 's',
                      readsFileName,
                      uniqueReadCount, '' if uniqueReadCount == 1 else 's',
                      self.sampleNames[sampleName]))
-                proteins.sort(key=titleGetter)
-                append('<ul class="protein-list">')
-                for proteinMatch in proteins:
+                append('<ul class="protein-list indented">')
+                for proteinTitle in sorted(proteins):
+                    proteinMatch = proteins[proteinTitle]
                     append(
                         '<li>'
                         '<span class="stats">'
@@ -450,22 +605,24 @@ class ProteinGrouper(object):
                     append('</li>')
 
                 append('</ul>')
-                append('</p>')
 
         # Write all samples (with viruses (with proteins)).
+        append('<hr>')
         append('<h1>Samples by virus</h1>')
-        result.extend(proteinFieldsDescription)
 
         for sampleName in sampleNames:
             sampleVirusTitles = set()
             for virusTitle in virusTitles:
-                if sampleName in self.virusTitles[virusTitle]:
+                if (sampleName in self.virusTitles[virusTitle] and
+                        self.maxProteinFraction(virusTitle) >=
+                        minProteinFraction):
                     sampleVirusTitles.add(virusTitle)
 
             append(
-                '<a id="sample-%s">'
-                '<h2 class="sample"><span class="sample-name">%s</span> '
-                '(has proteins from %d virus%s, <a href="%s">panel</a>)</h2>' %
+                '<a id="sample-%s"></a>'
+                'Sample <span class="sample-name">%s</span> '
+                'matched proteins from %d virus%s, '
+                '<a href="%s">panel</a>:<br/>' %
                 (sampleName, sampleName, len(sampleVirusTitles),
                  '' if len(sampleVirusTitles) == 1 else 'es',
                  self.sampleNames[sampleName]))
@@ -477,17 +634,30 @@ class ProteinGrouper(object):
                 uniqueReadCount = self.virusTitles[
                     virusTitle][sampleName]['uniqueReadCount']
                 proteinCount = len(proteins)
+                virusProteinCount = self._virusProteinCount[virusTitle]
+
+                highlight = ''
+                if virusProteinCount:
+                    proteinCountStr = '%d/%d protein%s' % (
+                        proteinCount, virusProteinCount,
+                        '' if virusProteinCount == 1 else 's')
+                    if proteinCount / virusProteinCount >= minProteinFraction:
+                        highlight = ('<span class="significant">%s</span>' %
+                                     highlightSymbol)
+                else:
+                    proteinCountStr = '%d protein%s' % (
+                        proteinCount, '' if proteinCount == 1 else 's')
+
                 append(
-                    '<p class="sample">'
-                    '<span class="virus-title">%s</span> '
-                    '(%d protein%s, <a href="%s">%d read%s</a>)' %
-                    (virusTitle,
-                     proteinCount, '' if proteinCount == 1 else 's',
-                     readsFileName,
+                    '<p class="sample indented">'
+                    '%s<a href="#virus-%s">%s</a> %s, '
+                    '<a href="%s">%d read%s</a>:</p>' %
+                    (highlight, virusTitle, virusTitle,
+                     proteinCountStr, readsFileName,
                      uniqueReadCount, '' if uniqueReadCount == 1 else 's'))
-                proteins.sort(key=titleGetter)
-                append('<ul class="protein-list">')
-                for proteinMatch in proteins:
+                append('<ul class="protein-list indented">')
+                for proteinTitle in sorted(proteins):
+                    proteinMatch = proteins[proteinTitle]
                     append(
                         '<li>'
                         '<span class="stats">'
@@ -513,7 +683,6 @@ class ProteinGrouper(object):
                     append('</li>')
 
                 append('</ul>')
-                append('</p>')
 
         append('</body>')
         append('</html>')

--- a/dark/proteins.py
+++ b/dark/proteins.py
@@ -414,11 +414,23 @@ class ProteinGrouper(object):
                 border-style: inset;
                 border-width: 1px;
             }
+            p.virus {
+                margin-top: 10px;
+                margin-bottom: 3px;
+            }
+            p.sample {
+                margin-top: 10px;
+                margin-bottom: 3px;
+            }
             .significant {
                 color: red;
                 margin-right: 2px;
             }
             .sample {
+                margin-top: 5px;
+                margin-bottom: 2px;
+            }
+            ul {
                 margin-bottom: 2px;
             }
             .indented {
@@ -544,8 +556,9 @@ class ProteinGrouper(object):
             virusProteinCount = self._virusProteinCount[virusTitle]
             append(
                 '<a id="virus-%s"></a>'
-                '<span class="virus-title"><a href="%s%s">%s</a></span>'
-                '%s, was matched by %d sample%s:' %
+                '<p class="virus"><span class="virus-title">'
+                '<a href="%s%s">%s</a></span>'
+                '%s, was matched by %d sample%s:</p>' %
                 (virusTitle, self.VIRALZONE, quote(virusTitle),
                  virusTitle,
                  ((' (with %d protein%s)' %
@@ -570,7 +583,7 @@ class ProteinGrouper(object):
                 append(
                     '<p class="sample indented">'
                     '%sSample <a href="#sample-%s">%s</a> '
-                    '(%d protein%s, <a href="%s">%d read%s</a>, '
+                    '(%d protein%s, <a href="%s">%d de-duplicated read%s</a>, '
                     '<a href="%s">panel</a>):</p>' %
                     (highlight, sampleName, sampleName,
                      proteinCount, '' if proteinCount == 1 else 's',
@@ -620,9 +633,9 @@ class ProteinGrouper(object):
 
             append(
                 '<a id="sample-%s"></a>'
-                'Sample <span class="sample-name">%s</span> '
+                '<p class="sample">Sample <span class="sample-name">%s</span> '
                 'matched proteins from %d virus%s, '
-                '<a href="%s">panel</a>:<br/>' %
+                '<a href="%s">panel</a>:</p>' %
                 (sampleName, sampleName, len(sampleVirusTitles),
                  '' if len(sampleVirusTitles) == 1 else 'es',
                  self.sampleNames[sampleName]))
@@ -651,7 +664,7 @@ class ProteinGrouper(object):
                 append(
                     '<p class="sample indented">'
                     '%s<a href="#virus-%s">%s</a> %s, '
-                    '<a href="%s">%d read%s</a>:</p>' %
+                    '<a href="%s">%d de-duplicated read%s</a>:</p>' %
                     (highlight, virusTitle, virusTitle,
                      proteinCountStr, readsFileName,
                      uniqueReadCount, '' if uniqueReadCount == 1 else 's'))

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ scripts = [
 ]
 
 setup(name='dark-matter',
-      version='1.0.103',
+      version='1.0.105',
       packages=['dark', 'dark.blast', 'dark.diamond'],
       include_package_data=True,
       url='https://github.com/acorg/dark-matter',

--- a/test/test_proteins.py
+++ b/test/test_proteins.py
@@ -3,7 +3,9 @@ from six import StringIO, assertRaisesRegex
 from six.moves import builtins
 from contextlib import contextmanager
 
-from dark.proteins import ProteinGrouper, VirusSampleFiles
+from dark.proteins import (
+    splitTitles, _NO_VIRUS_TITLE, getVirusProteinCounts, ProteinGrouper,
+    VirusSampleFiles)
 
 try:
     from unittest.mock import patch
@@ -11,6 +13,101 @@ except ImportError:
     from mock import patch
 
 from .mocking import File
+
+
+class TestSplitTitles(TestCase):
+    """
+    Tests for the splitTitles function.
+    """
+
+    def testNoBrackets(self):
+        """
+        If a string with no trailing virus name in square brackets is given,
+        splitTitles must return its argument followed by a string indicating
+        no virus name could be found.
+        """
+        self.assertEqual(('xxx', _NO_VIRUS_TITLE), splitTitles('xxx'))
+
+    def testTwoSetsOfBrackets(self):
+        """
+        If a string with two trailing substrings in square brackets is given,
+        splitTitles must extract the substring from the second set of square
+        brackets and use that as the virus name.
+        """
+        self.assertEqual(('xxx [other]', 'virus'),
+                         splitTitles('xxx [other] [virus]'))
+
+    def testWhitespaceStripping(self):
+        """
+        If a string with titles that have whitespace is passed, splitTitles
+        must strip the whitespace in its result.
+        """
+        self.assertEqual(('xxx', 'virus'),
+                         splitTitles(' xxx [ virus ]'))
+
+    def testNestedBrackets(self):
+        """
+        If a string with two nested trailing substrings in square brackets is
+        given, splitTitles must return its argument followed by a string
+        indicating no virus name could be found.
+        """
+        self.assertEqual(('xxx [nested [virus name]]', _NO_VIRUS_TITLE),
+                         splitTitles('xxx [nested [virus name]]'))
+
+    def testNormalCase(self):
+        """
+        If a string with a protein and virus title is passed, splitTitles
+        must return the expected result.
+        """
+        self.assertEqual(('protein title', 'virus title'),
+                         splitTitles('protein title [virus title]'))
+
+
+class TestGetVirusProteinCounts(TestCase):
+    """
+    Tests for the getVirusProteinCounts function.
+    """
+    def testNone(self):
+        """
+        getVirusProteinCounts must return an empty result if passed None as
+        the protein FASTA file.
+        """
+        self.assertEqual({}, getVirusProteinCounts(None))
+
+    def testExpected(self):
+        """
+        getVirusProteinCounts must return the expected result.
+        """
+        class SideEffect(object):
+            def __init__(self, test):
+                self.test = test
+                self.count = 0
+
+            def sideEffect(self, filename, **kwargs):
+                if self.count == 0:
+                    self.test.assertEqual('filename.fasta', filename)
+                    self.count += 1
+                    return File(['>protein 1 [virus 1]\n',
+                                 'ACTG\n',
+                                 '>protein 2 [virus 1]\n',
+                                 'AA\n',
+                                 '>no virus name here\n',
+                                 'AA\n',
+                                 '>protein 3 [virus 2]\n',
+                                 'AA\n'])
+                else:
+                    self.test.fail('We are only supposed to be called once!')
+
+        sideEffect = SideEffect(self)
+        with patch.object(builtins, 'open') as mockMethod:
+            mockMethod.side_effect = sideEffect.sideEffect
+            self.assertEqual(
+                {
+                    'virus 1': 2,
+                    'virus 2': 1,
+                },
+                getVirusProteinCounts('filename.fasta'))
+            self.assertEqual(1, sideEffect.count)
 
 
 class TestProteinGrouper(TestCase):
@@ -60,6 +157,20 @@ class TestProteinGrouper(TestCase):
         self.assertEqual({}, pg.virusTitles)
         self.assertEqual({}, pg.sampleNames)
 
+    def testDuplicateVirusProteinSample(self):
+        """
+        If a protein grouper is given duplicate information for a
+        virus/protein/sample combination it must raise a ValueError.
+        """
+        fp = StringIO(
+            '0.77 46.6 48.1 5 6 74 gi|327|X|I44.6 ubiquitin [Lausannevirus]\n')
+        pg = ProteinGrouper()
+        pg.addFile('sample', fp)
+        fp.seek(0)
+        error = ("^Protein 'gi\|327\|X\|I44.6 ubiquitin' already seen for "
+                 "virus 'Lausannevirus' sample 'sample'\.$")
+        assertRaisesRegex(self, ValueError, error, pg.addFile, 'sample', fp)
+
     def testOneLineInOneFile(self):
         """
         If a protein grouper is given one file with one line, its virusTitles
@@ -73,8 +184,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'sample-filename': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327|X|I44.6 ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.77,
@@ -89,7 +200,7 @@ class TestProteinGrouper(TestCase):
                                     'http://www.ncbi.nlm.nih.gov/nuccore/I44'),
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 }
@@ -109,8 +220,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'sample-filename': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327|X|I44.6 ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.77,
@@ -125,7 +236,7 @@ class TestProteinGrouper(TestCase):
                                     'http://www.ncbi.nlm.nih.gov/nuccore/I44'),
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 }
@@ -141,7 +252,9 @@ class TestProteinGrouper(TestCase):
             '0.77 46.6 48.1 5 6 74 gi|327|X|I44.6 ubiquitin [Lausannevirus]\n')
         pg = ProteinGrouper()
         pg.addFile('sample-filename', fp)
-        self.assertEqual('1 virus found in 1 sample', pg._title())
+        self.assertEqual(
+            'Overall, proteins from 1 virus were found in 1 sample.',
+            pg._title())
 
     def testTwoLinesInOneFileTitle(self):
         """
@@ -155,7 +268,9 @@ class TestProteinGrouper(TestCase):
             )
         pg = ProteinGrouper()
         pg.addFile('sample-filename', fp)
-        self.assertEqual('2 viruses found in 1 sample', pg._title())
+        self.assertEqual(
+            'Overall, proteins from 2 viruses were found in 1 sample.',
+            pg._title())
 
     def testTwoLinesInOneFileSameVirus(self):
         """
@@ -172,8 +287,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'sample-filename': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327410| protein 77': {
                                 'bestScore': 44.2,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.63,
@@ -187,7 +302,7 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 9,
                             },
-                            {
+                            'gi|327409| ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'out/1.png',
                                 'coverage': 0.77,
@@ -201,7 +316,7 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
@@ -223,8 +338,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'sample-filename': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327410| protein 77': {
                                 'bestScore': 44.2,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.63,
@@ -238,14 +353,14 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 9,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
                 'Hepatitis B virus': {
                     'sample-filename': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327409| ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'out/1.png',
                                 'coverage': 0.77,
@@ -259,7 +374,7 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
@@ -284,8 +399,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'sample-filename-1': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327410| protein 77': {
                                 'bestScore': 44.2,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.63,
@@ -299,12 +414,12 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 9,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                     'sample-filename-2': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327409| ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'out/0.png',
                                 'coverage': 0.77,
@@ -318,7 +433,7 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
@@ -339,7 +454,9 @@ class TestProteinGrouper(TestCase):
         pg = ProteinGrouper()
         pg.addFile('sample-filename-1', fp1)
         pg.addFile('sample-filename-2', fp2)
-        self.assertEqual('1 virus found in 2 samples', pg._title())
+        self.assertEqual(
+            'Overall, proteins from 1 virus were found in 2 samples.',
+            pg._title())
 
     def testOneLineInEachOfTwoFilesDifferentViruses(self):
         """
@@ -360,8 +477,8 @@ class TestProteinGrouper(TestCase):
             {
                 'Lausannevirus': {
                     'dir-1/sample-filename-1': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327410| protein 77': {
                                 'bestScore': 44.2,
                                 'bluePlotFilename': 'dir-1/out/0.png',
                                 'coverage': 0.63,
@@ -375,14 +492,14 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 9,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
                 'Hepatitis B virus': {
                     'dir-2/sample-filename-2': {
-                        'proteins': [
-                            {
+                        'proteins': {
+                            'gi|327409| ubiquitin': {
                                 'bestScore': 48.1,
                                 'bluePlotFilename': 'dir-2/out/0.png',
                                 'coverage': 0.77,
@@ -396,7 +513,7 @@ class TestProteinGrouper(TestCase):
                                 'proteinURL': None,
                                 'readCount': 5,
                             },
-                        ],
+                        },
                         'uniqueReadCount': None,
                     },
                 },
@@ -417,7 +534,9 @@ class TestProteinGrouper(TestCase):
         pg = ProteinGrouper()
         pg.addFile('sample-filename-1', fp1)
         pg.addFile('sample-filename-2', fp2)
-        self.assertEqual('2 viruses found in 2 samples', pg._title())
+        self.assertEqual(
+            'Overall, proteins from 2 viruses were found in 2 samples.',
+            pg._title())
 
     def testNoFilesToStr(self):
         """
@@ -425,93 +544,9 @@ class TestProteinGrouper(TestCase):
         format must as expected.
         """
         pg = ProteinGrouper()
-        self.assertEqual('0 viruses found in 0 samples\n', pg.toStr())
-
-    def testNoFilesToHTML(self):
-        """
-        If no files have been given to a protein grouper, its HTML string
-        format must as expected.
-        """
-        pg = ProteinGrouper()
         self.assertEqual(
-            '\n'.join([
-                '<html>',
-                '<head>',
-                '<title>',
-                '0 viruses found in 0 samples',
-                '</title>',
-                '</head>',
-                '<body>',
-                '<style>',
-                '            body {',
-                '                margin-left: 2%;',
-                '                margin-right: 2%;',
-                '            }',
-                '            .sample {',
-                '                margin-bottom: 2px;',
-                '            }',
-                '            .sample-name {',
-                '                color: red;',
-                '            }',
-                '            .index {',
-                '                font-size: small;',
-                '            }',
-                '            .protein-title {',
-                '                font-family: "Courier New", Courier, '
-                'monospace;',
-                '            }',
-                '            .stats {',
-                '                font-family: "Courier New", Courier, '
-                'monospace;',
-                '                white-space: pre;',
-                '            }',
-                '            .protein-list {',
-                '                margin-top: 2px;',
-                '            }',
-                '</style>',
-                '</head>',
-                '<body>',
-                '<h1>0 viruses found in 0 samples</h1>',
-                '<h2>Virus index</h2>',
-                '</p>',
-                '<h2>Sample index</h2>',
-                '</p>',
-                '<h1>Viruses by sample</h1>',
-                '<p>',
-                'In the bullet point protein lists below, there are eight '
-                'fields:',
-                '<ol>',
-                '<li>Coverage fraction.</li>',
-                '<li>Median bit score.</li>',
-                '<li>Best bit score.</li>',
-                '<li>Read count.</li>',
-                '<li>HSP count (a read can match a protein more than once).'
-                '</li>',
-                '<li>Protein length (in AAs).</li>',
-                '<li>Index (just ignore this).</li>',
-                '<li>Protein name.</li>',
-                '</ol>',
-                '</p>',
-                '<h1>Samples by virus</h1>',
-                '<p>',
-                'In the bullet point protein lists below, there are eight '
-                'fields:',
-                '<ol>',
-                '<li>Coverage fraction.</li>',
-                '<li>Median bit score.</li>',
-                '<li>Best bit score.</li>',
-                '<li>Read count.</li>',
-                '<li>HSP count (a read can match a protein more than once).'
-                '</li>',
-                '<li>Protein length (in AAs).</li>',
-                '<li>Index (just ignore this).</li>',
-                '<li>Protein name.</li>',
-                '</ol>',
-                '</p>',
-                '</body>',
-                '</html>',
-                ]),
-            pg.toHTML())
+            'Overall, proteins from 0 viruses were found in 0 samples.\n',
+            pg.toStr())
 
     def testOneLineInOneFileToStr(self):
         """
@@ -523,12 +558,67 @@ class TestProteinGrouper(TestCase):
         pg = ProteinGrouper()
         pg.addFile('sample-filename', fp)
         self.assertEqual(
-            '1 virus found in 1 sample\n'
+            'Overall, proteins from 1 virus were found in 1 sample.\n'
             '\n'
             'HBV (in 1 sample)\n'
             '  sample-filename (1 protein, 5 reads)\n'
             '    0.77\t46.60\t48.10\t   5\t   6\t  0\tgi|32|X|I4 protein X\n',
             pg.toStr())
+
+    def testMaxProteinFraction(self):
+        """
+        The maxProteinFraction method must return the correct values.
+        """
+        class SideEffect(object):
+            def __init__(self, test):
+                self.test = test
+                self.count = 0
+
+            def sideEffect(self, filename, **kwargs):
+                if self.count == 0:
+                    self.test.assertEqual('proteins.fasta', filename)
+                    self.count += 1
+                    return File(['>protein 1 [virus 1]\n',
+                                 'ACTG\n',
+                                 '>protein 2 [virus 1]\n',
+                                 'AA\n',
+                                 '>protein 3 [virus 1]\n',
+                                 'AA\n',
+                                 '>protein 4 [virus 1]\n',
+                                 'AA\n',
+                                 '>no virus name here\n',
+                                 'AA\n',
+                                 '>protein 5 [virus 2]\n',
+                                 'AA\n'])
+                else:
+                    self.test.fail('We are only supposed to be called once!')
+
+        sideEffect = SideEffect(self)
+        with patch.object(builtins, 'open') as mockMethod:
+            mockMethod.side_effect = sideEffect.sideEffect
+            pg = ProteinGrouper(proteinFastaFilename='proteins.fasta')
+            self.assertEqual(1, sideEffect.count)
+
+            fp = StringIO(
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 1 [virus 1]\n'
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 5 [virus 2]\n'
+            )
+            pg.addFile('sample-1', fp)
+
+            fp = StringIO(
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 2 [virus 1]\n'
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 3 [virus 1]\n'
+            )
+            pg.addFile('sample-1', fp)
+
+            fp = StringIO(
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 1 [virus 1]\n'
+                '0.77 46.6 48.1 5 6 74 gi|32|X|I4 protein 2 [virus 1]\n'
+            )
+            pg.addFile('sample-2', fp)
+
+            self.assertEqual(0.75, pg.maxProteinFraction('virus 1'))
+            self.assertEqual(1.0, pg.maxProteinFraction('virus 2'))
 
 
 class TestVirusSampleFiles(TestCase):

--- a/test/test_proteins.py
+++ b/test/test_proteins.py
@@ -112,7 +112,7 @@ class TestGetVirusProteinCounts(TestCase):
 
 class TestProteinGrouper(TestCase):
     """
-    Tests for the dark.proteins.ProteinGrouper class
+    Tests for the dark.proteins.ProteinGrouper class.
     """
 
     def testUnknownFormat(self):


### PR DESCRIPTION
These can be used to limit what is displayed in the HTML output, based on the fraction of proteins matched in viruses.

Fixes #506.
