### PR TITLE
getSequence is supposed to be called getSubjectSequence in dark/alignments.py

### DIFF
--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -5,4 +5,4 @@ if sys.version_info < (2, 7):
 
 # Note that the version string must have the following format, otherwise it
 # will not be found by the version() function in ../setup.py
-__version__ = '1.1.4'
+__version__ = '1.1.5'

--- a/dark/alignments.py
+++ b/dark/alignments.py
@@ -350,19 +350,21 @@ class ReadsAlignments(object):
         self.scoreClass = scoreClass
         self._filters = []
 
-    def getSequence(self, title):
+    def getSubjectSequence(self, title):
         """
         Obtain information about a sequence given its title.
 
         Must be implemented by a subclass, e.g., see
         L{blast.alignments.BlastReadsAlignments}.
 
-        @param title: A C{str} sequence title from a BLAST match. Of the form
+        @param title: A C{str} sequence title from a BLAST or DIAMOND (etc.)
+            match. Usually of the form
             'gi|63148399|gb|DQ011818.1| Description...'.
-        @return: A C{SeqIO.read} instance.
+        @raise NotImplementedError: This method must be implemented by a
+            subclass.
         """
-        raise NotImplementedError('getSequence must be implemented by a '
-                                  'subclass')
+        raise NotImplementedError('getSubjectSequence must be implemented by '
+                                  'a subclass')
 
     def hsps(self):
         """

--- a/test/test_alignments.py
+++ b/test/test_alignments.py
@@ -209,13 +209,13 @@ class TestReadsAlignments(TestCase):
         readsAlignments = ReadsAlignments(reads, 'applicationName', None)
         self.assertEqual([], list(readsAlignments))
 
-    def testGetSequence(self):
+    def testGetSubjectSequence(self):
         """
-        A ReadsAlignments instance will not implement getSequence. Subclasses
-        are expected to implement it.
+        A ReadsAlignments instance will not implement getSubjectSequence.
+        Subclasses are expected to implement it.
         """
         reads = Reads()
         readsAlignments = ReadsAlignments(reads, 'applicationName', None)
         error = 'getSequence must be implemented by a subclass'
         six.assertRaisesRegex(self, NotImplementedError, error,
-                              readsAlignments.getSequence, 'title')
+                              readsAlignments.getSubjectSequence, 'title')


### PR DESCRIPTION
This was not causing an error because the BLAST and DIAMOND subclasses were implementing `getSubjectSequence`.

Fixes #531.