### PR TITLE
Add a --sortFilenames arg to noninteractive-alignment-panel.py

### DIFF
--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -5,4 +5,4 @@ if sys.version_info < (2, 7):
 
 # Note that the version string must have the following format, otherwise it
 # will not be found by the version() function in ../setup.py
-__version__ = '1.1.12'
+__version__ = '1.1.13'

--- a/dark/diamond/alignments.py
+++ b/dark/diamond/alignments.py
@@ -53,7 +53,7 @@ class DiamondReadsAlignments(ReadsAlignments):
 
     def __init__(self, reads, filenames, databaseFilename=None,
                  databaseDirectory=None, sqliteDatabaseFilename=None,
-                 scoreClass=HigherIsBetterScore, sortFilenames=True,
+                 scoreClass=HigherIsBetterScore, sortFilenames=False,
                  randomizeZeroEValues=True):
         if databaseFilename is None and sqliteDatabaseFilename is None:
             raise ValueError(

--- a/test/diamond/test_alignments.py
+++ b/test/diamond/test_alignments.py
@@ -288,10 +288,11 @@ class TestDiamondReadsAlignments(TestCase):
             reads.add(Read('id2', 'A' * 70))
 
             # Note the files are given out of order. Their names will be
-            # sorted before they are opened. The sorting of the names is
-            # verified in the SideEffect class, above.
+            # sorted before they are opened (due to sortFilenames=True).
+            # The sorting of the names is verified in the SideEffect class,
+            # above.
             readsAlignments = DiamondReadsAlignments(
-                reads, ['3.json', '1.json', '2.json'],
+                reads, ['3.json', '1.json', '2.json'], sortFilenames=True,
                 databaseFilename='database.fasta')
             result = list(readsAlignments)
             self.assertEqual(3, len(result))


### PR DESCRIPTION
and pass it to the alignment classes as well as sorting the FASTA/Q inputs to match.

Fixes #542.