### PR TITLE
Correctly adjust quality string when gaps are removed from a read.

### DIFF
--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -5,4 +5,4 @@ if sys.version_info < (2, 7):
 
 # Note that the version string must have the following format, otherwise it
 # will not be found by the version() function in ../setup.py
-__version__ = '1.1.12'
+__version__ = '1.1.14'

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -992,11 +992,17 @@ class ReadFilter(object):
             return False
 
         if self.removeGaps:
-            # TODO: There's a bug here. The sequence can be shortened but
-            # the quality string (if any) is not. See
-            # https://github.com/acorg/dark-matter/issues/479
-            sequence = read.sequence.replace('-', '')
-            read = read.__class__(read.id, sequence, read.quality)
+            if read.quality is None:
+                read = read.__class__(read.id, read.sequence.replace('-', ''))
+            else:
+                newSequence = []
+                newQuality = []
+                for base, quality in zip(read.sequence, read.quality):
+                    if base != '-':
+                        newSequence.append(base)
+                        newQuality.append(quality)
+                read = read.__class__(
+                    read.id, ''.join(newSequence), ''.join(newQuality))
 
         if (self.titleFilter and
                 self.titleFilter.accept(read.id) == TitleFilter.REJECT):

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -2579,6 +2579,16 @@ class TestReadsFiltering(TestCase):
         result = reads.filter(removeGaps=True)
         self.assertEqual([Read('id', 'ATCG')], list(result))
 
+    def testFilterRemoveGapsWithQuality(self):
+        """
+        Filtering must be able to remove gaps, treating the quality string
+        properly.
+        """
+        reads = Reads()
+        reads.add(Read('id', '-AT--CG-', '12345678'))
+        result = reads.filter(removeGaps=True)
+        self.assertEqual([Read('id', 'ATCG', '2367')], list(result))
+
     def testFilterNegativeRegex(self):
         """
         Filtering must be able to filter reads based on a negative regular


### PR DESCRIPTION
Fixes #479.