### PR TITLE
Cleaned up and renamed etc., --indices and --keepIndices options to filter-fasta.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 2.0.0 April 17, 2018
+
+* The `--indices` option to `filter-fasta.py` was changed to accept a
+  string range (like 10-20,25-30,51,60) instead of a list of single
+  integers. It is renamed to `--keepSequences` and is also now 1-based not
+  0-based, like its friends `--keepSites`.
+* `--removeSequences` was added as an option to `filter-fasta.py`.
+* The options `--keepIndices`, `--keepIndicesFile`, `--removeIndices`, and
+  `removeIndicesFile` to `filter-fasta.py` are now named `--keepSites`,
+  `--keepSitesFile`, `--removeSites`, and `removeSitesFile` though the old
+  names are still supported for now.
+* The `indicesMatching` methods of `Reads` is renamed to `sitesMatching`.
+* `removeSequences` was added to read filtering in `ReadFilter` and as a
+  `--removeSequences` option to `filter-fasta.py`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of Python tools for filtering and visualizing
 [Next Generation Sequencing](https://en.wikipedia.org/wiki/DNA_sequencing#Next-generation_methods)
 reads.
 
-Runs under Python 2.7, 3.5, and 3.6
+Runs under Python 2.7, 3.5, and 3.6. [Change log](CHANGELOG.md)
 [![Build Status](https://travis-ci.org/acorg/dark-matter.svg?branch=master)](https://travis-ci.org/acorg/dark-matter)
 
 ## Installation

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -5,4 +5,4 @@ if sys.version_info < (2, 7):
 
 # Note that the version string must have the following format, otherwise it
 # will not be found by the version() function in ../setup.py
-__version__ = '1.1.33'
+__version__ = '2.0.0'

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -225,31 +225,32 @@ class Read(object):
                              ''.join(sorted(self.ALPHABET)),
                              str(self.__class__.__name__)))
 
-    def newFromIndices(self, indices, exclude=False):
+    def newFromSites(self, sites, exclude=False):
         """
-        Create a new read from self, with only certain indices.
+        Create a new read from self, with only certain sites.
 
-        @param indices: A set of C{int} 0-based indices in sequences that
-            should be kept. If C{None} (the default), all indices are kept.
-        @param exclude: If C{True} the C{indices} will be excluded, not
+        @param sites: A set of C{int} 0-based sites (i.e., indices) in
+            sequences that should be kept. If C{None} (the default), all sites
+            are kept.
+        @param exclude: If C{True} the C{sites} will be excluded, not
             included.
         """
         if exclude:
-            indices = set(range(len(self))) - indices
+            sites = set(range(len(self))) - sites
 
         newSequence = []
         if self.quality:
             newQuality = []
             for index, (base, quality) in enumerate(zip(self.sequence,
                                                         self.quality)):
-                if index in indices:
+                if index in sites:
                     newSequence.append(base)
                     newQuality.append(quality)
             read = self.__class__(self.id, ''.join(newSequence),
                                   ''.join(newQuality))
         else:
             for index, base in enumerate(self.sequence):
-                if index in indices:
+                if index in sites:
                     newSequence.append(base)
             read = self.__class__(self.id, ''.join(newSequence))
 
@@ -610,23 +611,24 @@ class SSAARead(AARead):
         """
         return cls(d['id'], d['sequence'], d['structure'])
 
-    def newFromIndices(self, indices, exclude=False):
+    def newFromSites(self, sites, exclude=False):
         """
-        Create a new read from self, with only certain indices.
+        Create a new read from self, with only certain sites.
 
-        @param indices: A set of C{int} 0-based indices in sequences that
-            should be kept. If C{None} (the default), all indices are kept.
-        @param exclude: If C{True} the C{indices} will be excluded, not
+        @param sites: A set of C{int} 0-based sites (i.e., indices) in
+            sequences that should be kept. If C{None} (the default), all sites
+            are kept.
+        @param exclude: If C{True} the C{sites} will be excluded, not
             included.
         """
         if exclude:
-            indices = set(range(len(self))) - indices
+            sites = set(range(len(self))) - sites
 
         newSequence = []
         newStructure = []
         for index, (base, structure) in enumerate(zip(self.sequence,
                                                       self.structure)):
-            if index in indices:
+            if index in sites:
                 newSequence.append(base)
                 newStructure.append(structure)
         read = self.__class__(self.id, ''.join(newSequence),
@@ -746,8 +748,12 @@ class ReadFilter(object):
     @param truncateTitlesAfter: A string that read ids will be truncated
         beyond. If the truncated version of an id has already been seen,
         that sequence will be skipped.
-    @param indices: Either C{None} or a set of C{int} indices corresponding
-        to reads that are wanted. Indexing starts at zero.
+    @param keepSequences: Either C{None} or a set of C{int}s corresponding
+        to reads that should be kept. Indexing starts at zero. The numbers
+        refer to the sequential number of the sequence in the list of reads.
+    @param removeSequences: Either C{None} or a set of C{int}s corresponding
+        to reads that should be removed. Indexing starts at zero. The numbers
+        refer to the sequential number of the sequence in the list of reads.
     @param head: If not C{None}, the C{int} number of sequences at the
         start of the reads to return. Later sequences are skipped.
     @param removeDuplicates: If C{True} remove duplicated reads based only on
@@ -805,15 +811,16 @@ class ReadFilter(object):
         file containing (1-based) sequence numbers, in ascending order,
         one per line. Only those sequences matching the given numbers will
         be kept.
-    @keepIndices: A set of C{int} 0-based indices in sequences that should
-        be kept. If C{None} (the default), all indices are kept.
-    @removeIndices: A set of C{int} 0-based indices in sequences that should
-        be removed. If C{None} (the default), no indices are removed.
+    @keepSites: A set of C{int} 0-based sites (i.e., indices) in sequences
+        that should be kept. If C{None} (the default), all sites are kept.
+    @removeSites: A set of C{int} 0-based sites (i.e., indices) in sequences
+        that should be removed. If C{None} (the default), no sites are removed.
     @raises ValueError: If C{randomSubset} and C{sampleFraction} are both
         specified, or if C{randomSubset} is specified but C{trueLength} is not,
         or if the sequence numbers in C{sequenceNumbersFile} are
-        non-positive or not ascending, or if both C{keepIndices} and
-        C{removeIndices} are given.
+        non-positive or not ascending, or if both C{keepSites} and
+        C{removeSites} are given, or if both C{keepSequences} and
+        C{removeSequences} are given.
     """
 
     # TODO, when/if needed: make it possible to pass a seed for the RNG
@@ -825,12 +832,12 @@ class ReadFilter(object):
                  whitelist=None, blacklist=None,
                  whitelistFile=None, blacklistFile=None,
                  titleRegex=None, negativeTitleRegex=None,
-                 truncateTitlesAfter=None, indices=None, head=None,
+                 truncateTitlesAfter=None, keepSequences=None,
+                 removeSequences=None, head=None,
                  removeDuplicates=False, removeDuplicatesById=False,
                  removeDescriptions=False, modifier=None, randomSubset=None,
                  trueLength=None, sampleFraction=None,
-                 sequenceNumbersFile=None, keepIndices=None,
-                 removeIndices=None):
+                 sequenceNumbersFile=None, keepSites=None, removeSites=None):
 
         if randomSubset is not None:
             if sampleFraction is not None:
@@ -845,7 +852,6 @@ class ReadFilter(object):
         self.minLength = minLength
         self.maxLength = maxLength
         self.removeGaps = removeGaps
-        self.indices = indices
         self.head = head
         self.removeDuplicates = removeDuplicates
         self.removeDuplicatesById = removeDuplicatesById
@@ -854,12 +860,19 @@ class ReadFilter(object):
         self.randomSubset = randomSubset
         self.trueLength = trueLength
 
-        if keepIndices and removeIndices:
+        if keepSequences and removeSequences:
             raise ValueError(
-                'Cannot simultaneously filter using keepIndices and '
-                'removeIndices. Call filter twice in succession instead.')
-        self.keepIndices = keepIndices
-        self.removeIndices = removeIndices
+                'Cannot simultaneously filter using keepSequences and '
+                'removeSequences. Call filter twice in succession instead.')
+        self.keepSequences = keepSequences
+        self.removeSequences = removeSequences
+
+        if keepSites and removeSites:
+            raise ValueError(
+                'Cannot simultaneously filter using keepSites and '
+                'removeSites. Call filter twice in succession instead.')
+        self.keepSites = keepSites
+        self.removeSites = removeSites
 
         self.alwaysFalse = False
         self.yieldCount = 0
@@ -1011,7 +1024,12 @@ class ReadFilter(object):
                 self.titleFilter.accept(read.id) == TitleFilter.REJECT):
             return False
 
-        if self.indices is not None and self.readIndex not in self.indices:
+        if (self.keepSequences is not None and
+                self.readIndex not in self.keepSequences):
+            return False
+
+        if (self.removeSequences is not None and
+                self.readIndex in self.removeSequences):
             return False
 
         if self.removeDuplicates:
@@ -1033,10 +1051,10 @@ class ReadFilter(object):
 
         # We have to use 'is not None' in the following tests so the empty set
         # is processed properly.
-        if self.keepIndices is not None:
-            read = read.newFromIndices(self.keepIndices)
-        elif self.removeIndices is not None:
-            read = read.newFromIndices(self.removeIndices, exclude=True)
+        if self.keepSites is not None:
+            read = read.newFromSites(self.keepSites)
+        elif self.removeSites is not None:
+            read = read.newFromSites(self.removeSites, exclude=True)
 
         if self.removeDescriptions:
             read.id = read.id.split()[0]
@@ -1267,15 +1285,16 @@ class Reads(object):
             'countAtPosition': countAtPosition
         }
 
-    def indicesMatching(self, targets, matchCase, any_):
+    def sitesMatching(self, targets, matchCase, any_):
         """
-        Find indices that match a given set of target sequence bases.
+        Find sites (i.e., sequence indices) that match a given set of target
+        sequence bases.
 
         @param targets: A C{set} of sequence bases to look for.
         @param matchCase: If C{True}, case will be considered in matching.
-        @param any_: If C{True}, return indices that match in any read. Else
-            return indices that match in all reads.
-        @return: A C{set} of 0-based indices that indicate where the target
+        @param any_: If C{True}, return sites that match in any read. Else
+            return sites that match in all reads.
+        @return: A C{set} of 0-based sites that indicate where the target
             bases occur in our reads. An index will be in this set if any of
             our reads has any of the target bases in that location.
         """
@@ -1296,7 +1315,7 @@ class Reads(object):
                     result = matches
                 else:
                     result &= matches
-                # We can exit early if we run out of possible indices.
+                # We can exit early if we run out of possible sites.
                 if not result:
                     break
 

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -530,93 +530,93 @@ class TestRead(TestCase):
                  "alphabet \('ACGT'\) for read class DNARead.")
         six.assertRaisesRegex(self, ValueError, error, read.checkAlphabet)
 
-    def testKeepIndices(self):
+    def testKeepSites(self):
         """
-        If only a certain set of indices should be kept, newFromIndices should
+        If only a certain set of sites should be kept, newFromSites should
         return a read with the correct sequence.
         """
         self.assertEqual(Read('id1', 'TC'),
-                         Read('id1', 'ATCGAT').newFromIndices({1, 2}))
+                         Read('id1', 'ATCGAT').newFromSites({1, 2}))
 
-    def testKeepIndicesNoIndices(self):
+    def testKeepSitesNoSites(self):
         """
-        If only the empty set of indices should be kept, newFromIndices should
+        If only the empty set of sites should be kept, newFromSites should
         return a read with the correct (empty) sequence.
         """
         self.assertEqual(Read('id1', ''),
-                         Read('id1', 'ATCGAT').newFromIndices(set()))
+                         Read('id1', 'ATCGAT').newFromSites(set()))
 
-    def testKeepIndicesAllIndices(self):
+    def testKeepSitesAllSites(self):
         """
-        If all indices should be kept, newFromIndices should return a read with
+        If all sites should be kept, newFromSites should return a read with
         the correct (full) sequence.
         """
         self.assertEqual(Read('id1', 'ATCGAT'),
-                         Read('id1', 'ATCGAT').newFromIndices(set(range(6))))
+                         Read('id1', 'ATCGAT').newFromSites(set(range(6))))
 
-    def testKeepIndicesWithQuality(self):
+    def testKeepSitesWithQuality(self):
         """
-        If only a certain set of indices should be kept, newFromIndices should
+        If only a certain set of sites should be kept, newFromSites should
         return a read with the correct sequence and quality.
         """
         self.assertEqual(Read('id1', 'TC', '23'),
-                         Read('id1', 'ATCGAT', '123456').newFromIndices(
+                         Read('id1', 'ATCGAT', '123456').newFromSites(
                              {1, 2}))
 
-    def testKeepIndicesOutOfRange(self):
+    def testKeepSitesOutOfRange(self):
         """
-        If only a certain set of indices should be kept, but the kept indices
-        are higher than the length of the input sequences, newFromIndices
+        If only a certain set of sites should be kept, but the kept sites
+        are higher than the length of the input sequences, newFromSites
         should return a read with the correct (empty) sequence.
         """
         self.assertEqual(Read('id1', ''),
-                         Read('id1', 'ATCGAT').newFromIndices({100, 200}))
+                         Read('id1', 'ATCGAT').newFromSites({100, 200}))
 
-    def testRemoveIndices(self):
+    def testRemoveSites(self):
         """
-        If only a certain set of indices should be removed, newFromIndices
+        If only a certain set of sites should be removed, newFromSites
         should return a read with the correct sequence.
         """
         self.assertEqual(Read('id1', 'AGAT'),
-                         Read('id1', 'ATCGAT').newFromIndices({1, 2},
-                                                              exclude=True))
+                         Read('id1', 'ATCGAT').newFromSites({1, 2},
+                                                            exclude=True))
 
-    def testRemoveIndicesNoIndices(self):
+    def testRemoveSitesNoSites(self):
         """
-        If no indices should be removed, newFromIndices should return a read
+        If no sites should be removed, newFromSites should return a read
         with the correct (full) sequence.
         """
         self.assertEqual(Read('id1', 'ATCGAT'),
-                         Read('id1', 'ATCGAT').newFromIndices(set(),
-                                                              exclude=True))
+                         Read('id1', 'ATCGAT').newFromSites(set(),
+                                                            exclude=True))
 
-    def testRemoveIndicesAllIndices(self):
+    def testRemoveSitesAllSites(self):
         """
-        If all indices should be removed, newFromIndices should return a read
+        If all sites should be removed, newFromSites should return a read
         with the correct (empty) sequence.
         """
         self.assertEqual(Read('id1', ''),
-                         Read('id1', 'ATCGAT').newFromIndices(set(range(6)),
-                                                              exclude=True))
+                         Read('id1', 'ATCGAT').newFromSites(set(range(6)),
+                                                            exclude=True))
 
-    def testRemoveIndicesWithQuality(self):
+    def testRemoveSitesWithQuality(self):
         """
-        If only a certain set of indices should be removed, newFromIndices
+        If only a certain set of sites should be removed, newFromSites
         should return a read with the correct sequence and quality.
         """
         self.assertEqual(Read('id1', 'AGAT', '1456'),
-                         Read('id1', 'ATCGAT', '123456').newFromIndices(
+                         Read('id1', 'ATCGAT', '123456').newFromSites(
                              {1, 2}, exclude=True))
 
-    def testRemoveIndicesOutOfRange(self):
+    def testRemoveSitesOutOfRange(self):
         """
-        If only a certain set of indices should be removed, but the removed
-        indices are higher than the length of the input sequences,
-        newFromIndices should return a read with the correct (full) sequence.
+        If only a certain set of sites should be removed, but the removed
+        sites are higher than the length of the input sequences,
+        newFromSites should return a read with the correct (full) sequence.
         """
         self.assertEqual(Read('id1', 'ATCGAT'),
-                         Read('id1', 'ATCGAT').newFromIndices({100, 200},
-                                                              exclude=True))
+                         Read('id1', 'ATCGAT').newFromSites({100, 200},
+                                                            exclude=True))
 
 
 class TestDNARead(TestCase):
@@ -1801,78 +1801,78 @@ class _TestSSAAReadMixin(object):
         read = self.CLASS('id', 'AA', 'HH')
         self.assertEqual(1, len(dict.fromkeys([read, read])))
 
-    def testKeepIndices(self):
+    def testKeepSites(self):
         """
-        If only a certain set of indices should be kept, newFromIndices should
+        If only a certain set of sites should be kept, newFromSites should
         return a read with the correct sequence.
         """
         self.assertEqual(self.CLASS('id1', 'TC', 'HG'),
-                         self.CLASS('id1', 'ATCGAT', 'CHGCCX').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CHGCCX').newFromSites(
                              {1, 2}))
 
-    def testKeepIndicesNoIndices(self):
+    def testKeepSitesNoSites(self):
         """
-        If an empty set of indices should be kept, newFromIndices should
+        If an empty set of sites should be kept, newFromSites should
         return a read with the correct (empty) sequence.
         """
         self.assertEqual(self.CLASS('id1', '', ''),
-                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromSites(
                              set()))
 
-    def testKeepIndicesAllIndices(self):
+    def testKeepSitesAllSites(self):
         """
-        If all indices should be kept, newFromIndices should return a read
+        If all sites should be kept, newFromSites should return a read
         with the correct (full) sequence.
         """
         self.assertEqual(self.CLASS('id1', 'ATCGAT', 'CHGCCC'),
-                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromSites(
                              set(range(6))))
 
-    def testKeepIndicesOutOfRange(self):
+    def testKeepSitesOutOfRange(self):
         """
-        If only a certain set of indices should be kept, but the kept indices
-        are higher than the length of the input sequences, newFromIndices
+        If only a certain set of sites should be kept, but the kept sites
+        are higher than the length of the input sequences, newFromSites
         should return a read with the correct (empty) sequence.
         """
         self.assertEqual(self.CLASS('id1', '', ''),
-                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CHGCCC').newFromSites(
                              {100, 200}))
 
-    def testRemoveIndices(self):
+    def testRemoveSites(self):
         """
-        If only a certain set of indices should be removed, newFromIndices
+        If only a certain set of sites should be removed, newFromSites
         should return a read with the correct sequence.
         """
         self.assertEqual(self.CLASS('id1', 'AGAT', 'CSHG'),
-                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromSites(
                              {1, 2}, exclude=True))
 
-    def testRemoveIndicesNoIndices(self):
+    def testRemoveSitesNoSites(self):
         """
-        If the empty set of indices should be removed, newFromIndices
+        If the empty set of sites should be removed, newFromSites
         should return a read with the correct (full) sequence.
         """
         self.assertEqual(self.CLASS('id1', 'ATCGAT', 'CXXSHG'),
-                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromSites(
                              set(), exclude=True))
 
-    def testRemoveIndicesAllIndices(self):
+    def testRemoveSitesAllSites(self):
         """
-        If all indices should be removed, newFromIndices should return a read
+        If all sites should be removed, newFromSites should return a read
         with the correct (empty) sequence.
         """
         self.assertEqual(self.CLASS('id1', '', ''),
-                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'CXXSHG').newFromSites(
                              set(range(6)), exclude=True))
 
-    def testRemoveIndicesOutOfRange(self):
+    def testRemoveSitesOutOfRange(self):
         """
-        If only a certain set of indices should be removed, but the removed
-        indices are higher than the length of the input sequences,
-        newFromIndices should return a read with the correct (full) sequence.
+        If only a certain set of sites should be removed, but the removed
+        sites are higher than the length of the input sequences,
+        newFromSites should return a read with the correct (full) sequence.
         """
         self.assertEqual(self.CLASS('id1', 'ATCGAT', 'HGSTCC'),
-                         self.CLASS('id1', 'ATCGAT', 'HGSTCC').newFromIndices(
+                         self.CLASS('id1', 'ATCGAT', 'HGSTCC').newFromSites(
                              {100, 200}, exclude=True))
 
 
@@ -2496,7 +2496,7 @@ class TestReadsFiltering(TestCase):
         result = reads.filter(minLength=3)
         self.assertEqual(2, len(list(result)))
 
-    def testAddFiltersThenClearfilters(self):
+    def testAddFiltersThenClearFilters(self):
         """
         If filters are added and then all filters are cleared, the result must
         be the same as the reads that were originally added.
@@ -2654,16 +2654,48 @@ class TestReadsFiltering(TestCase):
         result = reads.filter(truncateTitlesAfter='cat')
         self.assertEqual([Read('cat 400', 'AA')], list(result))
 
-    def testFilterIndices(self):
+    def testFilterKeepSequencesNoSequences(self):
         """
-        Filtering must be able to filter reads based on their indices.
+        Filtering must be able to filter reads based on their sequential
+        number when no sequences are wanted.
+        """
+        reads = Reads((Read('cow', 'A'), Read('dog', 'G'), Read('cat', 'T')))
+        result = reads.filter(keepSequences=set())
+        self.assertEqual([], list(result))
+
+    def testFilterKeepSequences(self):
+        """
+        Filtering must be able to filter reads based on their sequential
+        number.
         """
         reads = Reads()
         reads.add(Read('cow', 'AA'))
         reads.add(Read('dog', 'GG'))
         reads.add(Read('cat', 'TT'))
-        result = reads.filter(indices=set([1]))
-        self.assertEqual([Read('dog', 'GG')], list(result))
+        result = reads.filter(keepSequences=set([0, 2]))
+        self.assertEqual([Read('cow', 'AA'), Read('cat', 'TT')], list(result))
+
+    def testFilterRemoveSequencesNoSequences(self):
+        """
+        Filtering must be able to filter reads based on their sequential
+        number when no sequences are excluded.
+        """
+        animals = [Read('cow', 'A'), Read('dog', 'G'), Read('cat', 'T')]
+        reads = Reads(animals)
+        result = reads.filter(removeSequences=set())
+        self.assertEqual(animals, list(result))
+
+    def testFilterRemoveSequences(self):
+        """
+        Filtering must be able to exclude reads based on their sequential
+        number.
+        """
+        reads = Reads()
+        reads.add(Read('cow', 'AA'))
+        reads.add(Read('dog', 'GG'))
+        reads.add(Read('cat', 'TT'))
+        result = reads.filter(removeSequences=set([1]))
+        self.assertEqual([Read('cow', 'AA'), Read('cat', 'TT')], list(result))
 
     def testFilterHeadZero(self):
         """
@@ -3004,9 +3036,9 @@ class TestReadsFiltering(TestCase):
             result = reads.filter(sequenceNumbersFile='file')
             self.assertEqual([read1, read3], list(result))
 
-    def testKeepIndices(self):
+    def testKeepSites(self):
         """
-        If only a certain set of indices should be kept, the correct sequences
+        If only a certain set of sites should be kept, the correct sequences
         should be returned.
         """
         read1 = Read('id1', 'ATCGAT')
@@ -3014,7 +3046,7 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'AT')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(keepIndices={1, 2})
+        result = reads.filter(keepSites={1, 2})
         self.assertEqual(
             [
                 Read('id1', 'TC'),
@@ -3024,9 +3056,9 @@ class TestReadsFiltering(TestCase):
             ],
             list(result))
 
-    def testKeepIndicesNoIndices(self):
+    def testKeepSitesNoSites(self):
         """
-        If the empty set of indices should be kept, the correct (empty)
+        If the empty set of sites should be kept, the correct (empty)
         sequences should be returned.
         """
         read1 = Read('id1', 'ATCGAT')
@@ -3034,7 +3066,7 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'AT')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(keepIndices=set())
+        result = reads.filter(keepSites=set())
         self.assertEqual(
             [
                 Read('id1', ''),
@@ -3044,9 +3076,9 @@ class TestReadsFiltering(TestCase):
             ],
             list(result))
 
-    def testKeepIndicesAllIndices(self):
+    def testKeepSitesAllSites(self):
         """
-        If the set of all indices should be kept, the correct (full) sequences
+        If the set of all sites should be kept, the correct (full) sequences
         should be returned.
         """
         read1 = Read('id1', 'ATCGAT')
@@ -3054,28 +3086,28 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'AT')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(keepIndices=set(range(6)))
+        result = reads.filter(keepSites=set(range(6)))
         self.assertEqual([read1, read2, read3, read4], list(result))
 
-    def testKeepIndicesWithQuality(self):
+    def testKeepSitesWithQuality(self):
         """
-        If only a certain set of indices should be kept, the correct sequences
+        If only a certain set of sites should be kept, the correct sequences
         should be returned, including a modified quality string.
         """
         reads = Reads(initialReads=[Read('id1', 'ATCGAT', '123456')])
-        result = reads.filter(keepIndices={1, 2})
+        result = reads.filter(keepSites={1, 2})
         self.assertEqual([Read('id1', 'TC', '23')], list(result))
 
-    def testKeepIndicesOutOfRange(self):
+    def testKeepSitesOutOfRange(self):
         """
-        If only a certain set of indices should be kept, but the kept indices
+        If only a certain set of sites should be kept, but the kept sites
         are higher than the length of the input sequences, the correct
         (empty) sequences should be returned.
         """
         read1 = Read('id1', 'ATCG')
         read2 = Read('id2', 'ATCGCC')
         reads = Reads(initialReads=[read1, read2])
-        result = reads.filter(keepIndices={100, 200})
+        result = reads.filter(keepSites={100, 200})
         self.assertEqual(
             [
                 Read('id1', ''),
@@ -3083,9 +3115,9 @@ class TestReadsFiltering(TestCase):
             ],
             list(result))
 
-    def testRemoveIndices(self):
+    def testRemoveSites(self):
         """
-        If a certain set of indices should be removed, the correct sequences
+        If a certain set of sites should be removed, the correct sequences
         should be returned.
         """
         read1 = Read('id1', 'ATCGCC')
@@ -3093,7 +3125,7 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'A')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(removeIndices={1, 2})
+        result = reads.filter(removeSites={1, 2})
         self.assertEqual(
             [
                 Read('id1', 'AGCC'),
@@ -3103,9 +3135,9 @@ class TestReadsFiltering(TestCase):
             ],
             list(result))
 
-    def testRemoveIndicesNoIndices(self):
+    def testRemoveSitesNoSites(self):
         """
-        If the empty set of indices should be removed, the correct (full)
+        If the empty set of sites should be removed, the correct (full)
         sequences should be returned.
         """
         read1 = Read('id1', 'ATCGCC')
@@ -3113,13 +3145,13 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'A')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(removeIndices=set())
+        result = reads.filter(removeSites=set())
         self.assertEqual([read1, read2, read3, read4],
                          list(result))
 
-    def testRemoveIndicesAllIndices(self):
+    def testRemoveSitesAllSites(self):
         """
-        If the full set of indices should be removed, the correct (empty)
+        If the full set of sites should be removed, the correct (empty)
         sequences should be returned.
         """
         read1 = Read('id1', 'ATCGCC')
@@ -3127,7 +3159,7 @@ class TestReadsFiltering(TestCase):
         read3 = Read('id3', 'ATC')
         read4 = Read('id4', 'A')
         reads = Reads(initialReads=[read1, read2, read3, read4])
-        result = reads.filter(removeIndices=set(range(6)))
+        result = reads.filter(removeSites=set(range(6)))
         self.assertEqual(
             [
                 Read('id1', ''),
@@ -3137,36 +3169,36 @@ class TestReadsFiltering(TestCase):
             ],
             list(result))
 
-    def testRemoveIndicesWithQuality(self):
+    def testRemoveSitesWithQuality(self):
         """
-        If a certain set of indices should be removed, the correct sequences
+        If a certain set of sites should be removed, the correct sequences
         should be returned, including a modified quality string.
         """
         reads = Reads(initialReads=[Read('id1', 'ATCGAT', '123456')])
-        result = reads.filter(removeIndices={1, 2})
+        result = reads.filter(removeSites={1, 2})
         self.assertEqual([Read('id1', 'AGAT', '1456')], list(result))
 
-    def testRemoveIndicesOutOfRange(self):
+    def testRemoveSitesOutOfRange(self):
         """
-        If a certain set of indices should be removed, but the indices
+        If a certain set of sites should be removed, but the sites
         are higher than the length of the input sequences, the correct
         (full) sequences should be returned.
         """
         read1 = Read('id1', 'ATCG')
         read2 = Read('id2', 'ATCGAA')
         reads = Reads(initialReads=[read1, read2])
-        result = reads.filter(removeIndices={100, 200})
+        result = reads.filter(removeSites={100, 200})
         self.assertEqual([read1, read2], list(result))
 
-    def testRemoveAndKeepIndices(self):
+    def testRemoveAndKeepSites(self):
         """
-        Passing a keepIndices and a removeIndices set to reads.filter
+        Passing a keepSites and a removeSites set to reads.filter
         must result in a ValueError.
         """
-        error = ('^Cannot simultaneously filter using keepIndices and '
-                 'removeIndices. Call filter twice in succession instead\.$')
+        error = ('^Cannot simultaneously filter using keepSites and '
+                 'removeSites. Call filter twice in succession instead\.$')
         six.assertRaisesRegex(self, ValueError, error, Reads().filter,
-                              keepIndices={4}, removeIndices={5})
+                              keepSites={4}, removeSites={5})
 
 
 class TestReadsInRAM(TestCase):
@@ -3349,103 +3381,103 @@ class TestSummarizePosition(TestCase):
         self.assertEqual({'a': 1, 't': 2}, result['countAtPosition'])
 
 
-class TestIndicesMatching(TestCase):
+class TestSitesMatching(TestCase):
     """
-    Tests for the Reads.indicesMatching method.
+    Tests for the Reads.sitesMatching method.
     """
     def testNoMatches(self):
         """
-        If no reads match the target bases, indicesMatching must return the
+        If no reads match the target bases, sitesMatching must return the
         empty set.
         """
         reads = Reads()
         reads.add(Read('id1', 'aaaaaa'))
-        result = reads.indicesMatching({'b'}, matchCase=True, any_=True)
+        result = reads.sitesMatching({'b'}, matchCase=True, any_=True)
         self.assertEqual(set(), result)
 
     def testAllMatches(self):
         """
-        If a read's indices all match the target bases, indicesMatching must
-        return the full set of indices.
+        If a read's sites all match the target bases, sitesMatching must
+        return the full set of sites.
         """
         reads = Reads()
         reads.add(Read('id1', 'aaaga'))
-        result = reads.indicesMatching({'a', 'g'}, matchCase=True, any_=True)
+        result = reads.sitesMatching({'a', 'g'}, matchCase=True, any_=True)
         self.assertEqual(set(range(5)), result)
 
     def testPartialMatch(self):
         """
-        If some of a read's indices all match the target bases, indicesMatching
-        must return the expected set of indices.
+        If some of a read's sites all match the target bases, sitesMatching
+        must return the expected set of sites.
         """
         reads = Reads()
         reads.add(Read('id1', 'aaaga'))
-        result = reads.indicesMatching({'a'}, matchCase=True, any_=True)
+        result = reads.sitesMatching({'a'}, matchCase=True, any_=True)
         self.assertEqual({0, 1, 2, 4}, result)
 
     def testMatchCase(self):
         """
-        If only some of a read's indices all match the target bases with
-        matching case, indicesMatching must return the expected set of indices.
+        If only some of a read's sites all match the target bases with
+        matching case, sitesMatching must return the expected set of sites.
         """
         reads = Reads()
         reads.add(Read('id1', 'aAAga'))
-        result = reads.indicesMatching({'a'}, matchCase=True, any_=False)
+        result = reads.sitesMatching({'a'}, matchCase=True, any_=False)
         self.assertEqual({0, 4}, result)
 
     def testIgnoreCase(self):
         """
-        If only some of a read's indices all match the target bases with
-        matching case, indicesMatching must return the expected set of indices
+        If only some of a read's sites all match the target bases with
+        matching case, sitesMatching must return the expected set of sites
         when we tell it to ignore case.
         """
         reads = Reads()
         reads.add(Read('id1', 'aAAga'))
-        result = reads.indicesMatching({'a'}, matchCase=False, any_=False)
+        result = reads.sitesMatching({'a'}, matchCase=False, any_=False)
         self.assertEqual({0, 1, 2, 4}, result)
 
     def testMultipleReadsAny(self):
         """
-        If multiple reads are given, indicesMatching must return the expected
-        set of indices when we pass any_=True.
+        If multiple reads are given, sitesMatching must return the expected
+        set of sites when we pass any_=True.
         """
         reads = Reads()
         reads.add(Read('id1', 'aaaga'))
         reads.add(Read('id2', 'caata'))
-        result = reads.indicesMatching({'c', 'g'}, matchCase=False, any_=True)
+        result = reads.sitesMatching({'c', 'g'}, matchCase=False, any_=True)
         self.assertEqual({0, 3}, result)
 
     def testMultipleReadsAll(self):
         """
-        If multiple reads are given, indicesMatching must return the expected
-        set of indices when we pass any_=False.
+        If multiple reads are given, sitesMatching must return the expected
+        set of sites when we pass any_=False.
         """
         reads = Reads()
         reads.add(Read('id1', 'aaaga'))
         reads.add(Read('id2', 'caaga'))
-        result = reads.indicesMatching({'c', 'g'}, matchCase=False, any_=False)
+        result = reads.sitesMatching({'c', 'g'}, matchCase=False, any_=False)
         self.assertEqual({3}, result)
 
     def testMultipleReadsAllWithDifferingLengths(self):
         """
-        If multiple reads are given, indicesMatching must return the expected
-        set of indices when we pass any_=False and the reads have differing
+        If multiple reads are given, sitesMatching must return the expected
+        set of sites when we pass any_=False and the reads have differing
         lengths.
         """
         reads = Reads()
         reads.add(Read('id2', 'caa-agt-'))
         reads.add(Read('id1', '-aa-a'))
-        result = reads.indicesMatching({'-'}, matchCase=False, any_=False)
+        result = reads.sitesMatching({'-'}, matchCase=False, any_=False)
         self.assertEqual({3}, result)
 
     def testMultipleReadsAnyWithDifferingLengths(self):
         """
-        If multiple reads are given, indicesMatching must return the expected
-        set of indices when we pass any_=True and the reads have differing
+        If multiple reads are given, sitesMatching must return the expected
+        set of sites when we pass any_=True and the reads have differing
         lengths.
         """
         reads = Reads()
         reads.add(Read('id2', 'caa-agt-'))
         reads.add(Read('id1', '-aa-a'))
-        result = reads.indicesMatching({'-'}, matchCase=False, any_=True)
+        result = reads.sitesMatching({'-'}, matchCase=False, any_=True)
         self.assertEqual({0, 3, 7}, result)

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,12 @@ commands =
 [testenv:py27]
 deps =
     discover==0.4.0
-    -rrequirements-2.txt
+    -rrequirements.txt
 
 [testenv:py35]
 deps =
     discover==0.4.0
-    -rrequirements-3.txt
+    -rrequirements.txt
 
 [testenv:pypy]
 deps =


### PR DESCRIPTION
I've made the options naming clearer and the values taken consistent. There are

* --keepSequences
* --removeSequences
* --keepSites
* --keepSitesFile
* --removeSites
* --removeSitesFile

The `sequences` options refer to the numeric number of the sequence. The `sites` options refer to positions (indices) within a sequence. All are 1-based. All can take range args like `1-30,50,90-100`.