### PR TITLE
Fix proteins 579

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: check, pycodestyle, pyflakes, lint
 
 check:
-	python -m discover -v
+	env PYTHONPATH=. python -m discover -v
 
 tcheck:
-	trial --rterrors test
+	env PYTHONPATH=. trial --rterrors test
 
 pycodestyle:
 	find . -path './.tox' -prune -o -path './build' -prune -o -path './dist' -prune -o -name '*.py' -print0 | xargs -0 pycodestyle

--- a/bin/proteins-to-pathogens.py
+++ b/bin/proteins-to-pathogens.py
@@ -137,6 +137,12 @@ if __name__ == '__main__':
               'contain the lengths of all reads that match proteins for a '
               'pathogen.'))
 
+    parser.add_argument(
+        '--assetDir', default='out',
+        help=('The output directory where noninteractive-alignment-panel.py '
+              'puts its HTML, plots and FASTA or FASTQ files, needed for '
+              'using --html'))
+
     args = parser.parse_args()
 
     if not args.html:

--- a/bin/proteins-to-pathogens.py
+++ b/bin/proteins-to-pathogens.py
@@ -168,11 +168,11 @@ if __name__ == '__main__':
     else:
         proteinFastaFilenames = None
 
-    grouper = ProteinGrouper(sampleNameRegex=args.sampleNameRegex,
+    grouper = ProteinGrouper(assetDir=args.assetDir,
+                             sampleNameRegex=args.sampleNameRegex,
                              format_=args.format,
                              proteinFastaFilenames=proteinFastaFilenames,
-                             saveReadLengths=args.showReadLengths,
-                             assetDir=args.assetDir)
+                             saveReadLengths=args.showReadLengths)
 
     if args.filenames:
         filenames = args.filenames

--- a/bin/proteins-to-pathogens.py
+++ b/bin/proteins-to-pathogens.py
@@ -171,7 +171,8 @@ if __name__ == '__main__':
     grouper = ProteinGrouper(sampleNameRegex=args.sampleNameRegex,
                              format_=args.format,
                              proteinFastaFilenames=proteinFastaFilenames,
-                             saveReadLengths=args.showReadLengths)
+                             saveReadLengths=args.showReadLengths,
+                             assetDir=args.assetDir)
 
     if args.filenames:
         filenames = args.filenames

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.0.5'
+__version__ = '3.0.6'

--- a/dark/proteins.py
+++ b/dark/proteins.py
@@ -9,19 +9,9 @@ import numpy as np
 from textwrap import fill
 from collections import Counter
 
-try:
-    import matplotlib
-    if not os.environ.get('DISPLAY'):
-        # Use non-interactive Agg backend
-        matplotlib.use('Agg')
-    import matplotlib.pyplot as plt
-except ImportError:
-    import platform
-    if platform.python_implementation() == 'PyPy':
-        raise NotImplementedError(
-            'matplotlib is not supported under pypy')
-    else:
-        raise
+import matplotlib
+matplotlib.use('PDF')
+import matplotlib.pyplot as plt
 
 from dark.dimension import dimensionalIterator
 from dark.fasta import FastaReads

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -76,7 +76,7 @@ please install python.app and replace the use of 'python' with 'pythonw'. See
 ```
 You can solve this by adding a new matplotlibrc file for your virtual env.
 
-In your virtuan environment, do:
+In your virtual environment, do:
 ```
 $ cd ~/.matplotlib
 $ nano matplotlibrc #to create file using nano

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -56,6 +56,34 @@ If you're still on pypy 4, comment out the
 and follow the instructions in that file to install `numpy`. Then run the
 `pip install` command above.
 
+
 # Install a taxonomy database (optional)
 
 See [taxonomy.md](taxonomy.md) for details.
+
+
+# Running the tests
+
+If you run the tests using `make tcheck` you may encounter the following 
+error:
+
+``` 
+RuntimeError: Python is not installed as a framework. The Mac OS X backend 
+will not be able to function correctly if Python is not installed as a 
+framework. See the Python documentation for more information on installing 
+Python as a framework on Mac OS X. Please either reinstall Python as a 
+framework, or try one of the other backends. If you are using (Ana)Conda 
+please install python.app and replace the use of 'python' with 'pythonw'. See
+ 'Working with Matplotlib on OSX' in the Matplotlib FAQ for more information.
+```
+You can solve this by adding a new matplotlibrc file for your virtual env.
+
+In your virtuan environment, do:
+```
+$ cd ~/.matplotlib
+$ nano matplotlibrc #to create file using nano
+```
+Write `backend: TkAgg`in the file and save upon exit (`ctrl O` to save, `ctrl X` to exit)
+
+
+

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -74,11 +74,9 @@ framework, or try one of the other backends. If you are using (Ana)Conda
 please install python.app and replace the use of 'python' with 'pythonw'. See
  'Working with Matplotlib on OSX' in the Matplotlib FAQ for more information.
 ```
-You can solve this by adding a new matplotlibrc file for your virtual env.
 
-In your virtual environment, do:
+You can solve this by editing ~/.matplotlib/matplotlibrc (you may have to create the ~/.matplotlib directory) and inserting the following line:
+
 ```
-$ cd ~/.matplotlib
-$ nano matplotlibrc #to create file using nano
+backend: TkAgg
 ```
-Write `backend: TkAgg`in the file and save upon exit (`ctrl O` to save, `ctrl X` to exit)

--- a/doc/mac.md
+++ b/doc/mac.md
@@ -56,11 +56,9 @@ If you're still on pypy 4, comment out the
 and follow the instructions in that file to install `numpy`. Then run the
 `pip install` command above.
 
-
 # Install a taxonomy database (optional)
 
 See [taxonomy.md](taxonomy.md) for details.
-
 
 # Running the tests
 
@@ -84,6 +82,3 @@ $ cd ~/.matplotlib
 $ nano matplotlibrc #to create file using nano
 ```
 Write `backend: TkAgg`in the file and save upon exit (`ctrl O` to save, `ctrl X` to exit)
-
-
-

--- a/test/test_proteins.py
+++ b/test/test_proteins.py
@@ -255,6 +255,43 @@ class TestProteinGrouper(TestCase):
             },
             pg.pathogenNames)
 
+    def testOneLineInOneFileWithDifferentAssetDir(self):
+        """
+        If a protein grouper is given a different assetDir name, 
+        the outDir needs to have that same name, as expected.
+        """
+        fp = StringIO(
+            '0.77 46.6 48.1 5 6 74 gi|327|X|I44.6 ubiquitin [Lausannevirus]\n')
+        pg = ProteinGrouper(assetDir='differentname')
+        pg.addFile('sample-filename', fp)
+        self.assertEqual(
+            {
+                'Lausannevirus': {
+                    'sample-filename': {
+                        'proteins': {
+                            'gi|327|X|I44.6 ubiquitin': {
+                                'bestScore': 48.1,
+                                'bluePlotFilename': 'differentname/0.png',
+                                'coverage': 0.77,
+                                'readsFilename': 'differentname/0.fasta',
+                                'hspCount': 6,
+                                'index': 0,
+                                'medianScore': 46.6,
+                                'outDir': 'differentname',
+                                'proteinLength': 74,
+                                'proteinName': 'gi|327|X|I44.6 ubiquitin',
+                                'proteinURL': (
+                                    'http://www.ncbi.nlm.nih.gov/nuccore/I44'),
+                                'readCount': 5,
+                            },
+                        },
+                        'uniqueReadCount': None,
+                    },
+                }
+            },
+            pg.pathogenNames)
+
+
     def testOneLineInOneFileFASTQ(self):
         """
         If a protein grouper is given one file with one line, its pathogenNames

--- a/test/test_proteins.py
+++ b/test/test_proteins.py
@@ -291,7 +291,6 @@ class TestProteinGrouper(TestCase):
             },
             pg.pathogenNames)
 
-
     def testOneLineInOneFileFASTQ(self):
         """
         If a protein grouper is given one file with one line, its pathogenNames


### PR DESCRIPTION
Included an option for proteins-to-pathogens.py so that one can give an alternative assetDir (where the HTML, PNG and FASTA or FASTQ output of noninteractive-alignment-panels.py is saved). Wrote a test function to check if ProteinGrouper deals with an alternative assetDir as expected.

In the Makefile, a shortcut for check and check were added.

In proteins.py, changed code to PDF backend. 