### PR TITLE
Fixed handling of non-present (*) SEQ field in SAM/BAM files when the alignment is secondary or supplementary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.22 June 21, 2018
+
+Made `dark/sam.py` properly deal with secondary alignments that are missing
+a SEQ.
+
 ## 3.0.21 June 21, 2018
 
 Added `sam-reference-read-counts.py` script.

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.0.21'
+__version__ = '3.0.22'


### PR DESCRIPTION
Fixes #606.
