### PR TITLE
In dna.py, make identicalMatchCount only count non-ambiguous matches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.25 June 26, 2018
+
+Made a change in `dark/dna.py`, to make `identicalMatchCount` only count non-
+ambiguous matches. Added testfunction `testMatchwithIdenticalAmbuguity`.
+
 ## 3.0.24 June 25, 2018
 
 Made `noninteractive-alignment-panel.py` option `--outputDir` to be required.

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.0.24'
+__version__ = '3.0.25'

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -72,14 +72,14 @@ def compareDNAReads(read1, read2, matchAmbiguous=True, gapChars=('-'),
         return a == b and len(AMBIGUOUS[a]) == 1
 
     def _ambiguousMatch(a, b, matchAmbiguous):
-        return (matchAmbiguous and 
-                not _identicalMatch(a, b) and
-                AMBIGUOUS.get(a, empty) & AMBIGUOUS.get(b, empty))
         """
         Checks if two characters match ambiguously if matchAmbiguous is True. 
         A match is an ambiguous match if it is not an identical match, but the 
         sets of ambiguous characters overlap.
         """
+        return (matchAmbiguous and 
+                not _identicalMatch(a, b) and
+                AMBIGUOUS.get(a, empty) & AMBIGUOUS.get(b, empty))
 
     for offset, (a, b) in enumerate(zip_longest(read1.sequence.upper(),
                                                 read2.sequence.upper())):

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -109,7 +109,7 @@ def compareDNAReads(read1, read2, matchAmbiguous=True, gapChars=('-'),
                     # Neither is a gap character.
                     if len(AMBIGUOUS[b]) > 1:
                         read2AmbiguousOffsets.append(offset)
-                    if a == b:
+                    if a == b and len(AMBIGUOUS[a]) == 1:
                         identicalMatchCount += 1
                     elif matchAmbiguous and (
                             AMBIGUOUS.get(a, empty) & AMBIGUOUS.get(b, empty)):

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -110,16 +110,14 @@ def compareDNAReads(read1, read2, matchAmbiguous=True, gapChars=('-'),
                         read2AmbiguousOffsets.append(offset)
                     gapMismatchCount += 1
             else:
-                if b in gapChars:
-                    if len(AMBIGUOUS[a]) > 1:
+                if len(AMBIGUOUS[a]) > 1:
                         read1AmbiguousOffsets.append(offset)
+                if b in gapChars:
                     # b is a gap, a is not.
                     gapMismatchCount += 1
                     read2GapOffsets.append(offset)
                 else:
                     # Neither is a gap character.
-                    if len(AMBIGUOUS[a]) > 1:
-                        read1AmbiguousOffsets.append(offset)
                     if len(AMBIGUOUS[b]) > 1:
                         read2AmbiguousOffsets.append(offset)
                     if _identicalMatch(a, b):

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -87,12 +87,10 @@ def compareDNAReads(read1, read2, matchAmbiguous=True, gapChars=('-'),
         # to be passed.
         if offsets is not None and offset not in offsets:
             continue
-        if a is not None and a not in gapChars:    
-            if len(AMBIGUOUS[a]) > 1:
-                read1AmbiguousOffsets.append(offset)
-        if b is not None and b not in gapChars:
-            if len(AMBIGUOUS[b]) > 1:
-                read2AmbiguousOffsets.append(offset)
+        if len(AMBIGUOUS.get(a, '')) > 1:
+            read1AmbiguousOffsets.append(offset)
+        if len(AMBIGUOUS.get(b, '')) > 1:
+            read2AmbiguousOffsets.append(offset)
         if a is None:
             # b has an extra character at its end (it cannot be None).
             assert b is not None

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -263,6 +263,34 @@ class TestCompareDNAReads(TestCase):
             compareDNAReads(Read('id1', 'ACGTTC'),
                             Read('id2', 'ACGTTS')))
 
+    def testNonMatchingAmbiguityInFirst(self):
+        """
+        Two sequences that match exactly, apart from one ambiguity in the
+        second sequence, must compare as expected.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 1,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTW'),
+                            Read('id2', 'ACGTTC')))
+
     def testMatchWithAmbiguityInBoth(self):
         """
         Two sequences that match exactly, apart from one (compatible)
@@ -291,6 +319,35 @@ class TestCompareDNAReads(TestCase):
             },
             compareDNAReads(Read('id1', 'ACGTTK'),
                             Read('id2', 'ACGTTS')))
+
+    def testMatchWithAmbiguityInBothButStrict(self):
+        """
+        Two sequences that match exactly, apart from one (compatible)
+        ambiguity at the same location in the sequence, must compare as
+        expected. Strict.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 1,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTK'),
+                            Read('id2', 'ACGTTS'), matchAmbiguous=False))
 
     def testMatchWithIncompatibleAmbiguityInBoth(self):
         """
@@ -321,6 +378,35 @@ class TestCompareDNAReads(TestCase):
             compareDNAReads(Read('id1', 'ACGTTW'),
                             Read('id2', 'ACGTTS')))
 
+    def testMatchWithIncompatibleAmbiguityInBothButStrict(self):
+        """
+        Two sequences that match exactly, apart from one (incompatible)
+        ambiguity at the same location in the sequence, must compare as
+        expected. Strict.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 1,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTW'),
+                            Read('id2', 'ACGTTS'), matchAmbiguous=False))
+
     def testMatchWithIdenticalAmbiguity(self):
         """
         Two sequences that match exactly, including one (identical)
@@ -349,6 +435,35 @@ class TestCompareDNAReads(TestCase):
             },
             compareDNAReads(Read('id1', 'ACGTTN'),
                             Read('id2', 'ACGTTN')))
+
+    def testMatchWithIdenticalAmbiguityButStrict(self):
+        """
+        Two sequences that match exactly, including one (identical)
+        ambiguity at the same location in the sequence, must compare as
+        expected. Strict.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 1,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTN'),
+                            Read('id2', 'ACGTTN'), matchAmbiguous=False))
 
     def testGapInFirst(self):
         """
@@ -458,6 +573,34 @@ class TestCompareDNAReads(TestCase):
             },
             compareDNAReads(Read('id1', 'AC--T'),
                             Read('id2', 'A--TT')))
+
+    def testGapAmbigous(self):
+        """
+        Testing that the ambiguousOffset shows ambiguous characters paired
+        with gaps as expected
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 2,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 2,
+                    'gapGapMismatchCount': 1,
+                    'nonGapMismatchCount': 0,
+                },
+                'read1': {
+                    'ambiguousOffsets': [1],
+                    'extraCount': 0,
+                    'gapOffsets': [2, 3],
+                },
+                'read2': {
+                    'ambiguousOffsets': [3],
+                    'extraCount': 0,
+                    'gapOffsets': [1, 2],
+                },
+            },
+            compareDNAReads(Read('id1', 'AN--T'),
+                            Read('id2', 'A--NT')))
 
     def testExtraInFirst(self):
         """

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -265,8 +265,8 @@ class TestCompareDNAReads(TestCase):
 
     def testNonMatchingAmbiguityInFirst(self):
         """
-        Two sequences that match exactly, apart from one ambiguity in the
-        second sequence, must compare as expected.
+        Two sequences that match exactly, apart from one (incompatible) 
+        ambiguity in the second sequence, must compare as expected.
         """
         self.assertEqual(
             {
@@ -574,7 +574,7 @@ class TestCompareDNAReads(TestCase):
             compareDNAReads(Read('id1', 'AC--T'),
                             Read('id2', 'A--TT')))
 
-    def testGapAmbigous(self):
+    def testGapAmbiguous(self):
         """
         Testing that the ambiguousOffset shows ambiguous characters paired
         with gaps as expected

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -321,6 +321,35 @@ class TestCompareDNAReads(TestCase):
             compareDNAReads(Read('id1', 'ACGTTW'),
                             Read('id2', 'ACGTTS')))
 
+    def testMatchWithIdenticalAmbiguity(self):
+        """
+        Two sequences that match exactly, including one (indentical)
+        ambiguity at the same location in the sequence, must compare as
+        expected.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 1,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 1,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [5],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTN'),
+                            Read('id2', 'ACGTTN')))
+
     def testGapInFirst(self):
         """
         A gap in the first sequence must be dealt with correctly

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -658,6 +658,34 @@ class TestCompareDNAReads(TestCase):
             compareDNAReads(Read('id1', 'ACGTT'),
                             Read('id2', 'ACGTTCC')))
 
+    def testExtraAmbiguous(self):
+        """
+        If the first sequence has extra bases which are ambiguous,they must
+        be indicated in the extraCount and in the ambiguousOffset.
+        """
+        self.assertEqual(
+            {
+                'match': {
+                    'identicalMatchCount': 5,
+                    'ambiguousMatchCount': 0,
+                    'gapMismatchCount': 0,
+                    'gapGapMismatchCount': 0,
+                    'nonGapMismatchCount': 0,
+                },
+                'read1': {
+                    'ambiguousOffsets': [5, 6],
+                    'extraCount': 2,
+                    'gapOffsets': [],
+                },
+                'read2': {
+                    'ambiguousOffsets': [],
+                    'extraCount': 0,
+                    'gapOffsets': [],
+                },
+            },
+            compareDNAReads(Read('id1', 'ACGTTNN'),
+                            Read('id2', 'ACGTT')))
+
     def testMismatch(self):
         """
         If the sequences have mismatched (non-ambiguous) bases, their count

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -323,7 +323,7 @@ class TestCompareDNAReads(TestCase):
 
     def testMatchWithIdenticalAmbiguity(self):
         """
-        Two sequences that match exactly, including one (indentical)
+        Two sequences that match exactly, including one (identical)
         ambiguity at the same location in the sequence, must compare as
         expected.
         """
@@ -334,7 +334,7 @@ class TestCompareDNAReads(TestCase):
                     'ambiguousMatchCount': 1,
                     'gapMismatchCount': 0,
                     'gapGapMismatchCount': 0,
-                    'nonGapMismatchCount': 1,
+                    'nonGapMismatchCount': 0,
                 },
                 'read1': {
                     'ambiguousOffsets': [5],

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -673,9 +673,9 @@ class TestCompareDNAReads(TestCase):
                     'nonGapMismatchCount': 0,
                 },
                 'read1': {
-                    'ambiguousOffsets': [5, 6],
+                    'ambiguousOffsets': [6],
                     'extraCount': 2,
-                    'gapOffsets': [],
+                    'gapOffsets': [5],
                 },
                 'read2': {
                     'ambiguousOffsets': [],
@@ -683,7 +683,7 @@ class TestCompareDNAReads(TestCase):
                     'gapOffsets': [],
                 },
             },
-            compareDNAReads(Read('id1', 'ACGTTNN'),
+            compareDNAReads(Read('id1', 'ACGTT-N'),
                             Read('id2', 'ACGTT')))
 
     def testMismatch(self):


### PR DESCRIPTION
Fixes #573