### PR TITLE
Hard clipping fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.39 October 10, 2018
+
+The fix to solve [#630](https://github.com/acorg/dark-matter/issues/630)
+was insufficient. That's fixed in this release, hopefully!
+
 ## 3.0.38 October 5, 2018
 
 Fixed [#630](https://github.com/acorg/dark-matter/issues/630) to deal with

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.0.38'
+__version__ = '3.0.39'


### PR DESCRIPTION
The CIGAR hard-clipping fix in #631 was not sophisticated enough as it did not deal with operations that do not consume the query or with secondary/supplementary alignments that are missing the query/quality in the SAM/BAM file. Fixes #630 (hopefully).