### PR TITLE
Fix SAM alignments case where an unmapped no-CIGAR query is present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.44 Nov 1, 2018
+
+Fix [636](https://github.com/acorg/dark-matter/issues/636) in which SAM file
+parsing threw an exception when an unmapped sequence with no CIGAR string
+occurred in a SAM file (this can happen when running `bowtie2 --all`).
+
 ## 3.0.43 Nov 1, 2018
 
 Fixed thinko in 3.0.42.

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.0.43'
+__version__ = '3.0.44'

--- a/test/test_sam.py
+++ b/test/test_sam.py
@@ -247,6 +247,24 @@ class TestSAMFilter(TestCase):
             self.assertEqual('query1', alignment1.query_name)
             self.assertEqual('query4', alignment2.query_name)
 
+    def testCloseButNoCIGAR(self):
+        """
+        An unmapped query with no CIGAR string must be passed through
+        unchanged if dropUnmapped is not specified.
+        """
+        data = '\n'.join([
+            '@SQ SN:ref LN:10',
+            'query1 4 * 0 0 * * 0 0 TCTAGG ZZZZZZ',
+        ]).replace(' ', '\t')
+
+        with dataFile(data) as filename:
+            sf = SAMFilter(filename)
+            (alignment,) = list(sf.alignments())
+            self.assertEqual('query1', alignment.query_name)
+            self.assertEqual('TCTAGG', alignment.query_sequence)
+            self.assertEqual('ZZZZZZ', ''.join(
+                map(lambda x: chr(x + 33), alignment.query_qualities)))
+
 
 class TestPaddedSAM(TestCase):
     """


### PR DESCRIPTION
Fixes #636.