### PR TITLE
Kozak sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.64 Jan 31, 2019
+
+Fixed `AAread.ORFs` function in the `AARead` class and moved the
+`--allowOpenORFs` (True/False) check to within the function. Added a
+`DNAKozakRead` class. Changed `extract-ORFs.py` so that information
+about Kozak consensus sequences can be returned.
+
 ## 3.0.63 Jan 14, 2019
 
 Added `compareAaReads` and `matchToString` to `aa.py`. Wrote tests in 

--- a/bin/extract-ORFs.py
+++ b/bin/extract-ORFs.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
                         else:
                             # If all ORFs are wanted, write all ORFs to stdout.
                             print(orf.toString('fasta'), end='')
-                            # If extra Kozak consensus information is wanted:
+                        # If extra Kozak consensus information is wanted:
                         if kozakInfoFile:
                             for kozakread in findKozakConsensus(read):
                                 writeToKozakOut(kozakread, kozakInfoFile)

--- a/bin/extract-ORFs.py
+++ b/bin/extract-ORFs.py
@@ -95,43 +95,38 @@ if __name__ == '__main__':
             print('Quality of the Kozak consensus: ' +
                   str(kozakread.kozakQuality) + ' %', file=kozakfp)
 
-        def findORFs(kozakfp):
-            for read in reads:
-                try:
-                    for translation in translations(read):
-                        for orf in translation.ORFs(allowOpenORFs):
-                            # Check the length requirements, if any.
-                            if ((minORFLength is None or
-                               len(orf) >= minORFLength) and
-                               (maxORFLength is None or
-                               len(orf) <= maxORFLength)):
-                                # If only ORFs with a Kozak consensus
-                                # are wanted:
-                                if kozakOnly:
-                                    for kozakread in findKozakConsensus(read):
-                                        start = orf.start * 3
-                                        if (start + 1 <=
-                                           kozakread.stop <= start + 3):
-                                            print(orf.toString('fasta'),
-                                                  end='')
-                                else:
-                                    # If all ORFs are wanted,
-                                    # write all ORFs to stdout.
-                                    print(orf.toString('fasta'), end='')
-                                # If extra Kozak consensus information
-                                # is wanted:
-                                if kozakfp:
-                                    for kozakread in findKozakConsensus(read):
-                                        writeToKozakOut(kozakread, kozakfp)
+    def findORFs(kozakfp):
+        for read in reads:
+            try:
+                for translation in translations(read):
+                    for orf in translation.ORFs(allowOpenORFs):
+                        # Check the length requirements, if any.
+                        if ((minORFLength is None or
+                           len(orf) >= minORFLength) and
+                           (maxORFLength is None or
+                           len(orf) <= maxORFLength)):
 
-                except TranslationError as error:
-                    print('Could not translate read %r sequence %r (%s).' %
-                          (read.id, read.sequence, error), file=sys.stderr)
-                    if not aa:
-                        print('Did you forget to run '
-                              '%s with "--readClass AARead"?' %
-                              (basename(sys.argv[0])), file=sys.stderr)
-                    sys.exit(1)
+                            if kozakOnly:
+                                for kozakread in findKozakConsensus(read):
+                                    start = orf.start * 3
+                                    if (start + 1 <=
+                                       kozakread.stop <= start + 3):
+                                        print(orf.toString('fasta'),
+                                              end='')
+                            else:
+                                print(orf.toString('fasta'), end='')
+                            if kozakfp:
+                                for kozakread in findKozakConsensus(read):
+                                    writeToKozakOut(kozakread, kozakfp)
+
+            except TranslationError as error:
+                print('Could not translate read %r sequence %r (%s).' %
+                      (read.id, read.sequence, error), file=sys.stderr)
+                if not aa:
+                    print('Did you forget to run '
+                          '%s with "--readClass AARead"?' %
+                          (basename(sys.argv[0])), file=sys.stderr)
+                sys.exit(1)
 
     if kozakInfoFile:
         with open(kozakInfoFile, 'a+') as kozakfp:

--- a/bin/extract-ORFs.py
+++ b/bin/extract-ORFs.py
@@ -102,9 +102,9 @@ if __name__ == '__main__':
                     for orf in translation.ORFs(allowOpenORFs):
                         # Check the length requirements, if any.
                         if ((minORFLength is None or
-                           len(orf) >= minORFLength) and
-                           (maxORFLength is None or
-                           len(orf) <= maxORFLength)):
+                             len(orf) >= minORFLength) and
+                            (maxORFLength is None or
+                             len(orf) <= maxORFLength)):
 
                             if kozakOnly:
                                 for kozakread in findKozakConsensus(read):

--- a/bin/extract-ORFs.py
+++ b/bin/extract-ORFs.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         def writeToKozakOut(kozakread, kozakfp):
             """
             Writes out information about a Kozak sequence stored in kozakread
-            to the file name given in kozakInfoFile.
+            to the file name given in kozakfp.
             """
             print('Read ID: ' + kozakread.id, file=kozakfp)
             print('Kozak sequence: ' + kozakread.sequence, file=kozakfp)
@@ -117,7 +117,10 @@ if __name__ == '__main__':
                                 print(orf.toString('fasta'), end='')
                             if kozakfp:
                                 for kozakread in findKozakConsensus(read):
-                                    writeToKozakOut(kozakread, kozakfp)
+                                    start = orf.start * 3
+                                    if (start + 1 <=
+                                       kozakread.stop <= start + 3):
+                                        writeToKozakOut(kozakread, kozakfp)
 
             except TranslationError as error:
                 print('Could not translate read %r sequence %r (%s).' %

--- a/bin/extract-ORFs.py
+++ b/bin/extract-ORFs.py
@@ -83,44 +83,58 @@ if __name__ == '__main__':
         else:
             from dark.dna import findKozakConsensus
 
-        def writeToKozakOut(kozakread, kozakInfoFile):
+        def writeToKozakOut(kozakread, kozakfp):
             """
             Writes out information about a Kozak sequence stored in kozakread
             to the file name given in kozakInfoFile.
             """
-            with open(kozakInfoFile, 'a+') as kozakfp:
-                print('Read ID: ' + kozakread.id, file=kozakfp)
-                print('Kozak sequence: ' + kozakread.sequence, file=kozakfp)
-                print('Offset of the Kozak sequence A: ' +
-                      str(kozakread.start + 6), file=kozakfp)
-                print('Quality of the Kozak consensus: ' +
-                      str(kozakread.kozakQuality) + ' %', file=kozakfp)
+            print('Read ID: ' + kozakread.id, file=kozakfp)
+            print('Kozak sequence: ' + kozakread.sequence, file=kozakfp)
+            print('Offset of the Kozak sequence A: ' +
+                  str(kozakread.start + 6), file=kozakfp)
+            print('Quality of the Kozak consensus: ' +
+                  str(kozakread.kozakQuality) + ' %', file=kozakfp)
 
-    for read in reads:
-        try:
-            for translation in translations(read):
-                for orf in translation.ORFs(allowOpenORFs):
-                    # Check the length requirements, if any.
-                    if ((minORFLength is None or len(orf) >= minORFLength) and
-                       (maxORFLength is None or len(orf) <= maxORFLength)):
-                        # If only ORFs with a Kozak consensus are wanted:
-                        if kozakOnly:
-                            for kozakread in findKozakConsensus(read):
-                                start = orf.start * 3
-                                if (start + 1 <= kozakread.stop <= start + 3):
+        def findORFs(kozakfp):
+            for read in reads:
+                try:
+                    for translation in translations(read):
+                        for orf in translation.ORFs(allowOpenORFs):
+                            # Check the length requirements, if any.
+                            if ((minORFLength is None or
+                               len(orf) >= minORFLength) and
+                               (maxORFLength is None or
+                               len(orf) <= maxORFLength)):
+                                # If only ORFs with a Kozak consensus
+                                # are wanted:
+                                if kozakOnly:
+                                    for kozakread in findKozakConsensus(read):
+                                        start = orf.start * 3
+                                        if (start + 1 <=
+                                           kozakread.stop <= start + 3):
+                                            print(orf.toString('fasta'),
+                                                  end='')
+                                else:
+                                    # If all ORFs are wanted,
+                                    # write all ORFs to stdout.
                                     print(orf.toString('fasta'), end='')
-                        else:
-                            # If all ORFs are wanted, write all ORFs to stdout.
-                            print(orf.toString('fasta'), end='')
-                        # If extra Kozak consensus information is wanted:
-                        if kozakInfoFile:
-                            for kozakread in findKozakConsensus(read):
-                                writeToKozakOut(kozakread, kozakInfoFile)
+                                # If extra Kozak consensus information
+                                # is wanted:
+                                if kozakfp:
+                                    for kozakread in findKozakConsensus(read):
+                                        writeToKozakOut(kozakread, kozakfp)
 
-        except TranslationError as error:
-            print('Could not translate read %r sequence %r (%s).' %
-                  (read.id, read.sequence, error), file=sys.stderr)
-            if not aa:
-                print('Did you forget to run %s with "--readClass AARead"?' %
-                      (basename(sys.argv[0])), file=sys.stderr)
-            sys.exit(1)
+                except TranslationError as error:
+                    print('Could not translate read %r sequence %r (%s).' %
+                          (read.id, read.sequence, error), file=sys.stderr)
+                    if not aa:
+                        print('Did you forget to run '
+                              '%s with "--readClass AARead"?' %
+                              (basename(sys.argv[0])), file=sys.stderr)
+                    sys.exit(1)
+
+    if kozakInfoFile:
+        with open(kozakInfoFile, 'a+') as kozakfp:
+            findORFs(kozakfp)
+    else:
+        findORFs(None)

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -8,4 +8,4 @@ if sys.version_info < (2, 7):
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
 
-__version__ = '3.0.63'
+__version__ = '3.0.64'

--- a/dark/aa.py
+++ b/dark/aa.py
@@ -1,3 +1,4 @@
+
 from dark.utils import countPrint
 try:
     from itertools import zip_longest
@@ -1105,8 +1106,7 @@ def clustersForSequence(sequence, propertyNames, missingAAValue=0):
         sequence, propertyNames, PROPERTY_CLUSTERS, missingAAValue)
 
 
-def matchToString(aaMatch, read1, read2, indent='',
-                  offsets=None):
+def matchToString(aaMatch, read1, read2, indent='', offsets=None):
     """
     Format amino acid sequence match as a string.
 

--- a/dark/aa.py
+++ b/dark/aa.py
@@ -1,4 +1,3 @@
-
 from dark.utils import countPrint
 try:
     from itertools import zip_longest

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -222,8 +222,8 @@ def findKozakConsensus(read):
         """
         In a given DNA sequence, search for a Kozak consensus: (gcc)gccRccATGG.
         Upper case bases are required, lower case bases are the most frequent
-        bases at the given position. Sequence in brackets are of uncertain
-        significance and are not taken into account here.
+        bases at the given position. The sequence in brackets is of uncertain
+        significance and is not taken into account here.
 
         @param read: A C{DNARead} instance to be checked for Kozak consensi.
 
@@ -235,23 +235,20 @@ def findKozakConsensus(read):
         """
         readLen = len(read)
         offset = 0
+        readSeq = read.sequence
         while offset < readLen:
-            triplet = read.sequence[offset:offset + 3]
+            triplet = readSeq[offset:offset + 3]
             if triplet == 'ATG':
                 # Replace this with a regular expression?
-                if read.sequence[offset + 3] == 'G':
-                    if read.sequence[offset - 3] in 'GA':
-                        kozakQualityCount = 0
-                        if read.sequence[offset - 1] == 'C':
-                            kozakQualityCount += 1
-                        if read.sequence[offset - 2] == 'C':
-                            kozakQualityCount += 1
-                        if read.sequence[offset - 4] == 'C':
-                            kozakQualityCount += 1
-                        if read.sequence[offset - 5] == 'C':
-                            kozakQualityCount += 1
-                        if read.sequence[offset - 6] == 'G':
-                            kozakQualityCount += 1
+                if readSeq[offset + 3] == 'G':
+                    if readSeq[offset - 3] in 'GA':
+                        kozakQualityCount = sum((((
+                            readSeq[offset - 1] == 'C',
+                            readSeq[offset - 2] == 'C',
+                            readSeq[offset - 4] == 'C',
+                            readSeq[offset - 5] == 'C',
+                            readSeq[offset - 6] == 'G'))))
+
                         kozakQualityPercent = kozakQualityCount / 5 * 100
                         yield DNAKozakRead(read, offset - 6, offset + 4,
                                            kozakQualityPercent)

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -233,9 +233,9 @@ def findKozakConsensus(read):
         """
         readLen = len(read)
         if readLen > 9:
-            offset = 0
+            offset = 6
             readSeq = read.sequence
-            while offset < readLen + 3:
+            while offset < readLen - 3:
                 triplet = readSeq[offset:offset + 3]
                 if triplet == 'ATG':
                     if readSeq[offset + 3] == 'G':

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -236,20 +236,20 @@ def findKozakConsensus(read):
         readLen = len(read)
         offset = 0
         readSeq = read.sequence
-        while offset < readLen:
-            triplet = readSeq[offset:offset + 3]
-            if triplet == 'ATG':
-                # Replace this with a regular expression?
-                if readSeq[offset + 3] == 'G':
-                    if readSeq[offset - 3] in 'GA':
-                        kozakQualityCount = sum((((
-                            readSeq[offset - 1] == 'C',
-                            readSeq[offset - 2] == 'C',
-                            readSeq[offset - 4] == 'C',
-                            readSeq[offset - 5] == 'C',
-                            readSeq[offset - 6] == 'G'))))
+        if readLen > 9:
+            while offset < readLen + 3:
+                triplet = readSeq[offset:offset + 3]
+                if triplet == 'ATG':
+                    if readSeq[offset + 3] == 'G':
+                        if readSeq[offset - 3] in 'GA':
+                            kozakQualityCount = sum((
+                                readSeq[offset - 1] == 'C',
+                                readSeq[offset - 2] == 'C',
+                                readSeq[offset - 4] == 'C',
+                                readSeq[offset - 5] == 'C',
+                                readSeq[offset - 6] == 'G'))
 
-                        kozakQualityPercent = kozakQualityCount / 5 * 100
-                        yield DNAKozakRead(read, offset - 6, offset + 4,
-                                           kozakQualityPercent)
-            offset = offset + 1
+                            kozakQualityPercent = kozakQualityCount / 5 * 100
+                            yield DNAKozakRead(read, offset - 6, offset + 4,
+                                               kozakQualityPercent)
+                offset += 1

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -435,12 +435,12 @@ class AARead(Read):
                         if index:
                             yield AAReadORF(self, ORFStart, index, True, False)
                         inOpenORF = False
-                    if inORF:
+                    elif inORF:
                         if ORFStart != index:
                             yield AAReadORF(self, ORFStart, index,
                                             False, False)
                         inORF = False
-                if residue == 'M':
+                elif residue == 'M':
                     if not inOpenORF and not inORF:
                         ORFStart = index + 1
                         inORF = True
@@ -454,7 +454,7 @@ class AARead(Read):
                 yield AAReadORF(self, ORFStart, length, False, True)
 
         # Return only closed ORFs.
-        if not openORFs:
+        else:
             inORF = False
 
             for index, residue in enumerate(self.sequence):
@@ -462,14 +462,12 @@ class AARead(Read):
                     if not inORF:
                         inORF = True
                         ORFStart = index + 1
-                if residue == '*':
+                elif residue == '*':
                     if inORF:
-                        if ORFStart == index:
-                            inORF = False
-                        else:
+                        if not ORFStart == index:
                             yield AAReadORF(self, ORFStart,
                                             index, False, False)
-                            inORF = False
+                        inORF = False
 
 
 class AAReadWithX(AARead):
@@ -762,13 +760,13 @@ class TranslatedRead(AARead):
         new.reverseComplemented = d['reverseComplemented']
         return new
 
-    def maximumORFLength(self):
+    def maximumORFLength(self, openORFs=True):
         """
         Return the length of the longest (possibly partial) ORF in a translated
         read. The ORF may originate or terminate outside the sequence, which is
         why the length is just a lower bound.
         """
-        return max(len(orf) for orf in self.ORFs(True))
+        return max(len(orf) for orf in self.ORFs(openORFs))
 
 
 class ReadFilter(object):

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -460,7 +460,7 @@ class AARead(Read):
             length = len(self.sequence)
             if inOpenORF and length > 0:
                 yield AAReadORF(self, ORFStart, length, True, True)
-            elif inORF and ORFStart != index:
+            elif inORF and ORFStart < length:
                 yield AAReadORF(self, ORFStart, length, False, True)
 
         # Return only closed ORFs.

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -324,6 +324,42 @@ class RNARead(_NucleotideRead):
     COMPLEMENT_TABLE = _makeComplementTable(ambiguous_rna_complement)
 
 
+class DNAKozakRead(DNARead):
+    """
+    Hold information about a Kozak sequence.
+    """
+    def __init__(self, originalRead, start, stop, kozakQuality):
+        if start < 0:
+            raise ValueError('start offset (%d) less than zero' % start)
+        if stop > len(originalRead):
+            raise ValueError('stop offset (%d) > original read length (%d)' %
+                             (stop, len(originalRead)))
+        if start > stop:
+            raise ValueError('start offset (%d) greater than stop offset (%d)'
+                             % (start, stop))
+
+        newId = '%s-(%d:%d)' % (originalRead.id, start, stop)
+
+        if originalRead.quality:
+            DNARead.__init__(self, newId, originalRead.sequence[start:stop],
+                             originalRead.quality[start:stop])
+        else:
+            DNARead.__init__(self, newId, originalRead.sequence[start:stop])
+        self.originalRead = originalRead
+        self.start = start
+        self.stop = stop
+        self.kozakQuality = kozakQuality
+
+    def __eq__(self, other):
+        return (self.id == other.id and
+                self.sequence == other.sequence and
+                self.originalRead == other.originalRead and
+                self.quality == other.quality and
+                self.start == other.start and
+                self.stop == other.stop and
+                self.kozakQuality == other.kozakQuality)
+
+
 # Keep a single GOR4 instance that can be used by all AA reads. This saves us
 # from re-scanning the GOR IV secondary structure database every time we make
 # an AARead instance. This will be initialized when it's first needed.
@@ -378,41 +414,65 @@ class AARead(Read):
         """
         return (PROPERTY_DETAILS.get(aa, NONE) for aa in self.sequence)
 
-    def ORFs(self):
+    def ORFs(self, openORFs):
         """
         Find all ORFs in our sequence.
 
         @return: A generator that yields AAReadORF instances that correspond
             to the ORFs found in the AA sequence.
         """
-        ORFStart = None
-        openLeft = True
-        seenStart = False
+        # Return only closed ORFs.
+        if not openORFs:
+            inORF = False
 
-        for index, residue in enumerate(self.sequence):
-            if residue == 'M':
-                # Start codon.
-                openLeft = False
-                seenStart = True
-            elif residue == '*':
-                # Stop codon. Yield an ORF, if it has non-zero length.
-                if ORFStart is not None and index - ORFStart > 0:
-                    # The ORF has non-zero length.
-                    yield AAReadORF(self, ORFStart, index, openLeft, False)
-                    ORFStart = None
-                # After a stop codon, we can no longer be open on the left
-                # and we have no longer seen a start codon.
-                openLeft = seenStart = False
-            else:
-                if (seenStart or openLeft) and ORFStart is None:
-                    ORFStart = index
+            for index, residue in enumerate(self.sequence):
+                if residue == 'M':
+                    if not inORF:
+                        inORF = True
+                        ORFStart = index + 1
+                if residue == '*':
+                    if inORF:
+                        if ORFStart == index:
+                            inORF = False
+                        else:
+                            yield AAReadORF(self, ORFStart,
+                                            index, False, False)
+                            inORF = False
 
-        # End of sequence. Yield the final ORF if there is one and it has
-        # non-zero length.
-        length = len(self.sequence)
-        if ((seenStart or openLeft) and ORFStart is not None and
-                length - ORFStart > 0):
-            yield AAReadORF(self, ORFStart, length, openLeft, True)
+        # Return open ORFs to the left and right and closed ORFs within the
+        # sequence.
+        if openORFs:
+            ORFStart = 0
+            inOpenORF = True  # open on the left
+            inORF = False
+
+            for index, residue in enumerate(self.sequence):
+                if residue == '*':
+                    if inOpenORF:
+                        if index == 0:
+                            inOpenORF = False
+                        else:
+                            yield AAReadORF(self, ORFStart, index, True, False)
+                            inOpenORF = False
+                    if inORF:
+                        if ORFStart == index:
+                            inORF = False
+                        else:
+                            yield AAReadORF(self, ORFStart, index,
+                                            False, False)
+                            inORF = False
+                if residue == 'M':
+                    if not inOpenORF and not inORF:
+                        ORFStart = index + 1
+                        inORF = True
+
+            # End of sequence. Yield the final ORF, open to the right, if there
+            # is one and it has non-zero length.
+            length = len(self.sequence)
+            if inOpenORF and length > 0:
+                yield AAReadORF(self, ORFStart, length, True, True)
+            if inORF and ORFStart != index:
+                yield AAReadORF(self, ORFStart, length, False, True)
 
 
 class AAReadWithX(AARead):
@@ -711,7 +771,7 @@ class TranslatedRead(AARead):
         read. The ORF may originate or terminate outside the sequence, which is
         why the length is just a lower bound.
         """
-        return max(len(orf) for orf in self.ORFs())
+        return max(len(orf) for orf in self.ORFs(True))
 
 
 class ReadFilter(object):

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -428,6 +428,8 @@ class AARead(Read):
         """
         Find all ORFs in our sequence.
 
+        @param openORFs: If C{True} allow ORFs that do not have a start codon
+            and/or do not have a stop codon.
         @return: A generator that yields AAReadORF instances that correspond
             to the ORFs found in the AA sequence.
         """
@@ -455,8 +457,8 @@ class AARead(Read):
                         ORFStart = index + 1
                         inORF = True
 
-            # End of sequence. Yield the final ORF, open to the right, if there
-            # is one and it has non-zero length.
+            # End of sequence. Yield the final ORF, open to the right, if
+            # there is one and it has non-zero length.
             length = len(self.sequence)
             if inOpenORF and length > 0:
                 yield AAReadORF(self, ORFStart, length, True, True)

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -787,7 +787,7 @@ class TestFindKozakConsensus(TestCase):
     """
     def testNoSequence(self):
         """
-        If no string is passed, what should happen?
+        If no sequence is given, no ORF should be found.
         """
         read = DNARead('id', '')
         self.assertEqual([],

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -830,3 +830,37 @@ class TestFindKozakConsensus(TestCase):
 
         self.assertEqual([expectedKozakRead1, expectedKozakRead2],
                          list(findKozakConsensus(read)))
+
+    def testNoKozakConsensusAtEnd(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'ATTGCCTCCATGGGGATG')
+        self.assertEqual([], list(findKozakConsensus(read)))
+
+    def testKozakConsensusAtEnd(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'AAAAAAATTGCCGCCATGG')
+        expectedKozakRead = DNAKozakRead(read, 9, 19, 100.0)
+        (result,) = list(findKozakConsensus(read))
+        self.assertEqual(expectedKozakRead, result)
+
+    def testKozakConsensusATGStart(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'AAAATGGAAAAAAATTGCCGCC')
+        self.assertEqual([], list(findKozakConsensus(read)))
+
+    def testKozakConsensusAtEndPart(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'AAAAAAATTGCCGCCATG')
+        self.assertEqual([], list(findKozakConsensus(read)))

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -791,8 +791,7 @@ class TestFindKozakConsensus(TestCase):
         and quality percentage should be as expected.
         """
         read = DNARead('id', 'ATTGCCGCCATGGGGG')
-        expectedRead = DNARead('id', 'ATTGCCGCCATGGGGG')
-        expectedKozakRead = DNAKozakRead(expectedRead, 3, 13, 100.0)
+        expectedKozakRead = DNAKozakRead(read, 3, 13, 100.0)
 
         for kozakConsensus in findKozakConsensus(read):
             self.assertEqual(expectedKozakRead.id, kozakConsensus.id)

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -3,8 +3,9 @@ from unittest import TestCase
 from Bio.Alphabet.IUPAC import IUPACAmbiguousDNA
 
 from dark.dna import (
-    AMBIGUOUS, BASES_TO_AMBIGUOUS, compareDNAReads, matchToString)
-from dark.reads import Read
+    AMBIGUOUS, BASES_TO_AMBIGUOUS, compareDNAReads, matchToString,
+    findKozakConsensus)
+from dark.reads import Read, DNARead, DNAKozakRead
 
 
 class TestAmbiguousLetters(TestCase):
@@ -778,3 +779,57 @@ Mismatches: 0
     Ambiguous: 0''',
             matchToString(match, read1, read2, matchAmbiguous=True)
         )
+
+
+class TestFindKozakConsensus(TestCase):
+    """
+    Test the findKozakConsensus function.
+    """
+    def testOneKozakConsensus(self):
+        """
+        In a given sequence with an exact Kozak consensus sequence, the offset
+        and quality percentage should be as expected.
+        """
+        read = DNARead('id', 'ATTGCCGCCATGGGGG')
+        expectedRead = DNARead('id', 'ATTGCCGCCATGGGGG')
+        expectedKozakRead = DNAKozakRead(expectedRead, 3, 13, 100.0)
+
+        for kozakConsensus in findKozakConsensus(read):
+            self.assertEqual(expectedKozakRead.id, kozakConsensus.id)
+            self.assertEqual(expectedKozakRead.sequence,
+                             kozakConsensus.sequence)
+            self.assertEqual(3, kozakConsensus.start)
+            self.assertEqual(13, kozakConsensus.stop)
+            self.assertEqual(100.0, kozakConsensus.kozakQuality)
+
+    def testNoKozakConsensus1(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'ATTGCCTCCATGGGGG')
+        self.assertEqual([],
+                         list(findKozakConsensus(read)))
+
+    def testNoKozakConsensus2(self):
+        """
+        In a given sequence without a Kozak consensus, the output should be
+        as expected.
+        """
+        read = DNARead('id', 'ATTGCCGCCATGAGGG')
+        self.assertEqual([],
+                         list(findKozakConsensus(read)))
+
+    def testFindTwoKozakConsensi(self):
+        """
+        In a given sequence with two Kozak consensuses of different offsets
+        and qualities, the output should be as expected.
+        """
+        read = DNARead('id', 'ATTGCCGCCATGGGGGGCCATGG')
+        expectedRead1 = DNARead('id', 'ATTGCCGCCATGGGGGGCCATGG')
+        expectedRead2 = DNARead('id', 'ATTGCCGCCATGGGGGGCCATGG')
+        expectedKozakRead1 = DNAKozakRead(expectedRead1, 3, 13, 100.0)
+        expectedKozakRead2 = DNAKozakRead(expectedRead2, 13, 23, 60.0)
+
+        self.assertEqual([expectedKozakRead1, expectedKozakRead2],
+                         list(findKozakConsensus(read)))

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -785,6 +785,22 @@ class TestFindKozakConsensus(TestCase):
     """
     Test the findKozakConsensus function.
     """
+    def testNoSequence(self):
+        """
+        If no string is passed, what should happen?
+        """
+        read = DNARead('id', '')
+        self.assertEqual([],
+                         list(findKozakConsensus(read)))
+
+    def testShortSequence(self):
+        """
+        If a 4 nt long sequence is given, no ORF should be found.
+        """
+        read = DNARead('id', 'ATTG')
+        self.assertEqual([],
+                         list(findKozakConsensus(read)))
+
     def testOneKozakConsensus(self):
         """
         In a given sequence with an exact Kozak consensus sequence, the offset

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -839,8 +839,6 @@ class TestDNAKozakRead(TestCase):
         originalRead = DNARead('id', 'AAGTAAGGGCTGTGA')
         read = DNAKozakRead(originalRead, 2, 4, 100.0)
         self.assertEqual(2, read.start)
-        read = DNAKozakRead(originalRead, 4, 10, 100.0)
-        self.assertEqual(4, read.start)
 
     def testStop(self):
         """
@@ -857,7 +855,7 @@ class TestDNAKozakRead(TestCase):
         A DNAKozakRead start offset must not be less than zero.
         """
         originalRead = DNARead('id', 'AAGTAAGGGCTGTGA')
-        error = 'start offset \\(-1\\) less than zero'
+        error = r'^start offset \(-1\) less than zero$'
         six.assertRaisesRegex(
             self, ValueError, error, DNAKozakRead, originalRead, -1, 6, 100.0)
 
@@ -992,81 +990,72 @@ class TestAARead(TestCase):
         """
         An AA read of length zero must not have any ORFs.
         """
-        OpenORFs = True
         read = AARead('id', '')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(0, len(orfs))
 
     def testORFsEmptySequenceWithStartStop(self):
         """
         An AA read with just a start and stop codon must not have any ORFs.
         """
-        OpenORFs = False
         read = AARead('id', 'M*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(0, len(orfs))
 
     def testORFsEmptySequenceWithStartStopOpenORFs(self):
         """
         An AA read with just a start and stop codon must not have any ORFs.
         """
-        OpenORFs = True
         read = AARead('id', 'M*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
 
     def testORFsEmptySequenceWithStart(self):
         """
         An AA read with just a start codon must not have any ORFs.
         """
-        OpenORFs = False
         read = AARead('id', 'M')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(0, len(orfs))
 
     def testORFsEmptySequenceWithStartOpenORFs(self):
         """
         An AA read with just a start codon must not have any ORFs.
         """
-        OpenORFs = True
         read = AARead('id', 'M')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
 
     def testORFsWithOneStopCodon(self):
         """
         An AA read of a single stop codon must not have any ORFs.
         """
-        OpenORFs = False
         read = AARead('id', '*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(0, len(orfs))
 
     def testORFsWithOneStopCodonOpenORFs(self):
         """
         An AA read of a single stop codon must not have any ORFs.
         """
-        OpenORFs = True
         read = AARead('id', '*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(0, len(orfs))
 
     def testORFsWithTwoStopCodons(self):
         """
         An AA read of two stop codons must not have any ORFs.
         """
-        OpenORFs = True
         read = AARead('id', '**')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(0, len(orfs))
 
     def testORFsWithJustStartsAndStops(self):
         """
         An AA read of only start and stop codons must not have any ORFs.
         """
-        OpenORFs = False
         read = AARead('id', '**MM*M**MMM*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(2, len(orfs))
 
     def testOpenOpenORF(self):
@@ -1076,9 +1065,8 @@ class TestAARead(TestCase):
         the correct start/stop offsets and its left and right side must be
         marked as open.
         """
-        OpenORFs = True
         read = AARead('id', 'ADRADR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
         orf = orfs[0]
         self.assertEqual('ADRADR', orf.sequence)
@@ -1096,9 +1084,8 @@ class TestAARead(TestCase):
         left and right sides must be marked as open and closed,
         respectively.
         """
-        OpenORFs = True
         read = AARead('id', 'ADRADR*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
         orf = orfs[0]
         self.assertEqual('ADRADR', orf.sequence)
@@ -1116,9 +1103,8 @@ class TestAARead(TestCase):
         and its left and right sides must be marked as open and closed,
         respectively.
         """
-        OpenORFs = True
         read = AARead('id', 'ADRADR***')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
         orf = orfs[0]
         self.assertEqual('ADRADR', orf.sequence)
@@ -1136,9 +1122,8 @@ class TestAARead(TestCase):
         left and right sides must be marked as closed and open,
         respectively.
         """
-        OpenORFs = True
         read = AARead('id', 'MMMADRADR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
         orf = orfs[0]
         self.assertEqual('MMMADRADR', orf.sequence)
@@ -1155,9 +1140,8 @@ class TestAARead(TestCase):
         the correct start/stop offsets and its left and right sides must be
         both marked as closed.
         """
-        OpenORFs = False
         read = AARead('id', 'MADRADR*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(1, len(orfs))
         orf = orfs[0]
         self.assertEqual('ADRADR', orf.sequence)
@@ -1174,11 +1158,8 @@ class TestAARead(TestCase):
         the correct start/stop offsets and its left and right sides must be
         both marked as closed.
         """
-        OpenORFs = False
         read = AARead('id', 'AAAMADRADR*')
-        orfs = list(read.ORFs(OpenORFs))
-        self.assertEqual(1, len(orfs))
-        orf = orfs[0]
+        [orf] = list(read.ORFs(False))
         self.assertEqual('ADRADR', orf.sequence)
         self.assertEqual(4, orf.start)
         self.assertEqual(10, orf.stop)
@@ -1192,9 +1173,8 @@ class TestAARead(TestCase):
         followed by an ORF that is left closed and right open must have the
         ORFs detected correctly when its ORFs method is called.
         """
-        OpenORFs = True
         read = AARead('id', 'ADR*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(2, len(orfs))
 
         orf = orfs[0]
@@ -1219,9 +1199,8 @@ class TestAARead(TestCase):
         followed by an ORF that is left closed and right open must have the
         ORFs detected correctly when its ORFs method is called.
         """
-        OpenORFs = True
         read = AARead('id', '*MADR*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(2, len(orfs))
 
         orf = orfs[0]
@@ -1245,9 +1224,8 @@ class TestAARead(TestCase):
         An AA read that contains two ORFs that are both left and right closed
         must have the ORFs detected correctly when its ORFs method is called.
         """
-        OpenORFs = False
         read = AARead('id', 'MADR*MRRR*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(2, len(orfs))
 
         orf = orfs[0]
@@ -1273,9 +1251,8 @@ class TestAARead(TestCase):
         and right open must have the ORFs detected correctly when its ORFs
         method is called.
         """
-        OpenORFs = True
         read = AARead('id', 'ADR*MAAA*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(3, len(orfs))
 
         orf = orfs[0]
@@ -1309,9 +1286,8 @@ class TestAARead(TestCase):
         and right open must have the ORFs detected correctly when its ORFs
         method is called.
         """
-        OpenORFs = False
         read = AARead('id', 'MADR*MAAA*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(2, len(orfs))
 
         orf = orfs[0]
@@ -1337,9 +1313,8 @@ class TestAARead(TestCase):
         right closed must have the ORFs detected correctly when its ORFs
         method is called.
         """
-        OpenORFs = False
         read = AARead('id', 'MADR*MAAA*MRRR*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(3, len(orfs))
 
         orf = orfs[0]
@@ -1374,9 +1349,8 @@ class TestAARead(TestCase):
         method is called, including when there are intermediate start and
         stop codons.
         """
-        OpenORFs = True
         read = AARead('id', 'ADR***M*MAAA***MMM*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(4, len(orfs))
 
         orf = orfs[0]
@@ -1418,9 +1392,8 @@ class TestAARead(TestCase):
         and right open must have the ORFs detected correctly when its ORFs
         method is called.
         """
-        OpenORFs = True
         read = AARead('id', '**MADR***MM**MAAA***M*MRRR')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(4, len(orfs))
 
         orf = orfs[0]
@@ -1462,9 +1435,8 @@ class TestAARead(TestCase):
         right closed must have the ORFs detected correctly when its ORFs
         method is called.
         """
-        OpenORFs = False
         read = AARead('id', 'M***MADR***MAAA***MRRR***MM')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(False))
         self.assertEqual(3, len(orfs))
 
         orf = orfs[0]
@@ -1497,9 +1469,8 @@ class TestAARead(TestCase):
         as an ORF.
         """
         # Example from https://github.com/acorg/dark-matter/issues/239
-        OpenORFs = True
         read = AARead('id', 'KK*LLILFSCQRWSRKSICVHLTQR*G*')
-        orfs = list(read.ORFs(OpenORFs))
+        orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
 
         orf = orfs[0]

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -1004,11 +1004,19 @@ class TestAARead(TestCase):
 
     def testORFsEmptySequenceWithStartStopOpenORFs(self):
         """
-        An AA read with just a start and stop codon must not have any ORFs.
+        An AA read with just a start and stop codon must have one ORF.
         """
         read = AARead('id', 'M*')
         orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
+
+    def testORFsEmptySequenceWithStopStartOpenORFs(self):
+        """
+        An AA read with just a start and stop codon must have one ORF.
+        """
+        read = AARead('id', '*M')
+        orfs = list(read.ORFs(True))
+        self.assertEqual(0, len(orfs))
 
     def testORFsEmptySequenceWithStart(self):
         """
@@ -1020,9 +1028,17 @@ class TestAARead(TestCase):
 
     def testORFsEmptySequenceWithStartOpenORFs(self):
         """
-        An AA read with just a start codon must not have any ORFs.
+        An AA read with just a start codon must have one ORF.
         """
         read = AARead('id', 'M')
+        orfs = list(read.ORFs(True))
+        self.assertEqual(1, len(orfs))
+
+    def testORFsSequenceWithOneAAOpenORFs(self):
+        """
+        An AA read with just a start codon must have one ORF.
+        """
+        read = AARead('id', 'A')
         orfs = list(read.ORFs(True))
         self.assertEqual(1, len(orfs))
 

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -2054,9 +2054,18 @@ class TestTranslatedRead(TestCase):
         """
         The maximumORFLength function must return the correct value.
         """
-        read = Read('id', 'acctaggttgtttag')
+        read = Read('id', 'acctagatggttgtttag')
         translated = TranslatedRead(read, 'T*MVV*', 0)
         self.assertEqual(2, translated.maximumORFLength())
+
+    def testMaximumORFLengthNoOpenORF(self):
+        """
+        The maximumORFLength function must return the correct value if
+        open ORFs are not allowed.
+        """
+        read = Read('id', 'atgacctagatggttgtttag')
+        translated = TranslatedRead(read, 'MT*MVV*', 0)
+        self.assertEqual(2, translated.maximumORFLength(False))
 
     def testToDict(self):
         """

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -860,7 +860,6 @@ class TestDNAKozakRead(TestCase):
         error = 'start offset \\(-1\\) less than zero'
         six.assertRaisesRegex(
             self, ValueError, error, DNAKozakRead, originalRead, -1, 6, 100.0)
-        
 
     def testStartGreaterThanStop(self):
         """


### PR DESCRIPTION
Fixes #670
In `extract-ORFs.py` on line 91, I left in a comment. If someone gives a AA sequence, but parses `--kozakInfo` or `-- kozakOnly`, should the code break or is it enough to write an Error message to `stderr`?