### PR TITLE
Make compare-sequences.py fall back to use stretcher if the call to needle fails because the sequences are too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.40 Jan 17, 2020
+
+Make `compare-sequences.py` fall back to use `stretcher` if the call to
+`needle` fails because the sequences are too long.
+
 ## 3.1.39 Jan 17, 2020
 
 Fixed incorrect calculation of covered offset and total bases counts when

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '3.1.39'
+__version__ = '3.1.40'

--- a/dark/dna.py
+++ b/dark/dna.py
@@ -37,7 +37,7 @@ BASES_TO_AMBIGUOUS = dict(
 
 
 def matchToString(dnaMatch, read1, read2, matchAmbiguous=True, indent='',
-                  offsets=None):
+                  offsets=None, includeGapLocations=True):
     """
     Format a DNA match as a string.
 
@@ -51,6 +51,8 @@ def matchToString(dnaMatch, read1, read2, matchAmbiguous=True, indent='',
     @param indent: A C{str} to indent all returned lines with.
     @param offsets: If not C{None}, a C{set} of offsets of interest that were
         only considered when making C{match}.
+    @param includeGapLocations: If C{True} indicate the (1-based) locations of
+        gaps.
     @return: A C{str} describing the match.
     """
     match = dnaMatch['match']
@@ -94,7 +96,7 @@ def matchToString(dnaMatch, read1, read2, matchAmbiguous=True, indent='',
         append('%s    Length: %d' % (indent, length))
         gapCount = len(dnaMatch[key]['gapOffsets'])
         append(countPrint('%s    Gaps' % indent, gapCount, length))
-        if gapCount:
+        if includeGapLocations and gapCount:
             append(
                 '%s    Gap locations (1-based): %s' %
                 (indent,

--- a/dark/process.py
+++ b/dark/process.py
@@ -36,7 +36,9 @@ class Executor(object):
             the default setting (in C{self._dryRun}).
         @param useStderr: If C{True} print a summary of the command standard
             output and standard error to sys.stderr if the command results in
-            an error.
+            an exception. If a function is passed, the exception is passed to
+            the function and the summary is printed to sys.stderr if the
+            function returns C{True}.
         @param kwargs: Keyword arguments that will be passed to subprocess.run
             (or subprocess.check_call for Python version 2). Note that keyword
             arguments are not currently logged (the logging is slightly
@@ -72,6 +74,8 @@ class Executor(object):
                 result = run(command, check=True, stdout=PIPE, stderr=PIPE,
                              shell=shell, universal_newlines=True, **kwargs)
             except CalledProcessError as e:
+                if callable(useStderr):
+                    useStderr = useStderr(e)
                 if useStderr:
                     import sys
                     print('CalledProcessError:', e, file=sys.stderr)
@@ -84,6 +88,8 @@ class Executor(object):
                                     shell=shell, universal_newlines=True,
                                     **kwargs)
             except CalledProcessError as e:
+                if callable(useStderr):
+                    useStderr = useStderr(e)
                 if useStderr:
                     import sys
                     print('CalledProcessError:', e, file=sys.stderr)

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -780,6 +780,62 @@ Mismatches: 0
             matchToString(match, read1, read2, matchAmbiguous=True)
         )
 
+    def testGapLocations(self):
+        """
+        Gap locations must be returned correctly.
+        """
+        read1 = Read('id1', 'TTTTTAAAAAAGCGCG')
+        read2 = Read('id2', 'TTTTT------GCGCG')
+        match = compareDNAReads(read1, read2)
+        self.maxDiff = None
+        self.assertEqual(
+            '''\
+Exact matches: 10/16 (62.50%)
+Ambiguous matches: 0
+Mismatches: 6/16 (37.50%)
+  Not involving gaps (i.e., conflicts): 0
+  Involving a gap in one sequence: 6/16 (37.50%)
+  Involving a gap in both sequences: 0
+  Id: id1
+    Length: 16
+    Gaps: 0
+    Ambiguous: 0
+  Id: id2
+    Length: 16
+    Gaps: 6/16 (37.50%)
+    Gap locations (1-based): 6, 7, 8, 9, 10, 11
+    Ambiguous: 0''',
+            matchToString(match, read1, read2)
+        )
+
+    def testExcludeGapLocations(self):
+        """
+        If gap locations are not wanted, they should not appear in the result
+        of a call to matchToString.
+        """
+        read1 = Read('id1', 'TTTTTAAAAAAGCGCG')
+        read2 = Read('id2', 'TTTTT------GCGCG')
+        match = compareDNAReads(read1, read2)
+        self.maxDiff = None
+        self.assertEqual(
+            '''\
+Exact matches: 10/16 (62.50%)
+Ambiguous matches: 0
+Mismatches: 6/16 (37.50%)
+  Not involving gaps (i.e., conflicts): 0
+  Involving a gap in one sequence: 6/16 (37.50%)
+  Involving a gap in both sequences: 0
+  Id: id1
+    Length: 16
+    Gaps: 0
+    Ambiguous: 0
+  Id: id2
+    Length: 16
+    Gaps: 6/16 (37.50%)
+    Ambiguous: 0''',
+            matchToString(match, read1, read2, includeGapLocations=False)
+        )
+
 
 class TestFindKozakConsensus(TestCase):
     """


### PR DESCRIPTION
Fixes #706.