### PR TITLE
specify flag "dont-use-soft-clipped-bases true" when using gatk4

### DIFF
--- a/bin/run-bowtie2.py
+++ b/bin/run-bowtie2.py
@@ -118,8 +118,9 @@ def processMatch(args, e):
         bt2.makeBAM(args.samtoolsViewArgs)
 
     if args.sort and not (
-            args.markDuplicatesPicard or args.markDuplicatesGATK
-            or args.removePrimersFromBedFile):
+            args.markDuplicatesPicard or
+            args.markDuplicatesGATK or
+            args.removePrimersFromBedFile):
         bt2.sort()
 
     if args.removePrimersFromBedFile:

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -251,6 +251,7 @@ class Bowtie2(object):
             "--input '%s' "
             "--output '%s' "
             "--sample-ploidy 1 "
+            "--dont-use-soft-clipped-bases true"
             '-ERC GVCF' %
             (referenceFasta, inFile, vcfFile))
 

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -251,7 +251,7 @@ class Bowtie2(object):
             "--input '%s' "
             "--output '%s' "
             "--sample-ploidy 1 "
-            "--dont-use-soft-clipped-bases true"
+            "--dont-use-soft-clipped-bases true "
             '-ERC GVCF' %
             (referenceFasta, inFile, vcfFile))
 


### PR DESCRIPTION
this makes sure the that the soft-clipped reads are actually ignored when calling SNPs