### PR TITLE
fixed naming issue with temporary bam file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 .tox
 .DS_Store
+.idea
 _trial_temp
 __pycache__
 build

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -168,7 +168,7 @@ class Bowtie2(object):
         self._report("removing primers specified in %s" % bedFile)
         tempTrimmedBam = "%s.trimmed" % self._bamFile
         self._executor.execute(
-            "ivar trim -b %s -p %s -i %s -q 20 -m 30 -s 4 -e" %
+            "ivar trim -b '%s' -p '%s' -i '%s' -q 20 -m 30 -s 4 -e" %
             (bedFile, tempTrimmedBam, self._bamFile))
         self._executor.execute("mv %s '%s'" % (tempTrimmedBam, self._bamFile))
 

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -166,10 +166,11 @@ class Bowtie2(object):
             raise ValueError('makeBAM() has not yet been called.')
 
         self._report("removing primers specified in %s" % bedFile)
+        tempTrimmedBam = "%s.trimmed" % self._bamFile
         self._executor.execute(
-            "ivar trim -b %s -p result-trimmed -i %s -q 20 -m 30 -s 4 -e" %
-            (bedFile, self._bamFile))
-        self._executor.execute("mv result-trimmed.bam '%s'" % self._bamFile)
+            "ivar trim -b %s -p %s -i %s -q 20 -m 30 -s 4 -e" %
+            (bedFile, tempTrimmedBam, self._bamFile))
+        self._executor.execute("mv %s '%s'" % (tempTrimmedBam, self._bamFile))
 
     def markDuplicatesPicard(self, picardFile):
         """

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -170,7 +170,7 @@ class Bowtie2(object):
         self._executor.execute(
             "ivar trim -b '%s' -p '%s' -i '%s' -q 20 -m 30 -s 4 -e" %
             (bedFile, tempTrimmedBam, self._bamFile))
-        self._executor.execute("mv %s '%s'" % (tempTrimmedBam, self._bamFile))
+        self._executor.execute("mv '%s' '%s'" % (tempTrimmedBam, self._bamFile))
 
     def markDuplicatesPicard(self, picardFile):
         """


### PR DESCRIPTION
fixed naming issue with temporary bam file that is created when primers are soft-clipped. This resulted in a concurrency issue, as the file name was always the same and it gets deleted by other concurrent instances. It's now using the name of the bam file and just adds a suffix.