### PR TITLE
Add in-house consensus making

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.14 January 17, 2022
+
+Added a simple consensus caller.
+
 ## 4.0.13 December 28, 2021
 
 Added `bin/fasta-count-chars.py` script. Fixed argument bug in

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tcheck:
 	env PYTHONPATH=. trial --rterrors test
 
 pytest:
-	env PYTHONPATH=. pytest
+	env PYTHONPATH=. pytest --verbose
 
 pycodestyle:
 	find bin dark test -name '*.py' -print0 | $(XARGS) -0 pycodestyle --ignore E402,W504

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (2, 7):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '4.0.13'
+__version__ = '4.0.14'

--- a/dark/consensus.py
+++ b/dark/consensus.py
@@ -1,102 +1,85 @@
-from time import time
+# from time import time
 from collections import defaultdict
 
-# TODO: Some of these imported functions are no longer in utils.py!
-from dark.utils import findHits, getSequence, summarizeHits, printHSP, report
+from dark.dna import leastAmbiguousFromCounts
+from dark.sam import samfile
 
 
-def consensusSequence(recordFilename, hitId, fastaFilename, eCutoff=None,
-                      db='nt', actualSequenceId=None):
+def consensusFromBAM(bamFilename, reference, strategy='majority',
+                     threshold=0.8, minCoverage=1, lowCoverage='reference',
+                     noCoverage='reference'):
     """
-    Build a consensus sequence against a target sequence.
+    Build a consensus sequence from a BAM file.
 
-    recordFilename: the BLAST XML output file.
-    hitId: the str sequence id to examine the BLAST output for hits against.
-    fastaFilename: The name of the FASTA file containing query sequences,
-        or a list of fasta sequences from SeqIO.parse
-    eCutoff: converted e values less than this will be ignored.
-    db: the BLAST db to use to look up the target and, if given, actual
-        sequence.
-    actualSequenceId: the str id of the actual sequence (if known).
+    @param bamFilename: the BAM file.
+    @param reference: A C{Read} instance giving the reference sequence.
+    @param strategy: A C{str} strategy, one of 'majority'.
+    @param threshold: A C{float} threshold. This fraction, at least, of the
+        most-common nucleotides at a site are used to determine the consensus
+        nucleotide (or ambiguous symbol if more than one nucleotide is
+        required to achieve this threshold). If there is a tie in nucleotide
+        counts at a site that causes the threshold to be met, all nucleotides
+        of equeal frequncy will be included in the ambiguous symbol for that
+        site. This is perhaps better explained with an example. See
+        https://assets.geneious.com/manual/2020.1/static/GeneiousManualse43.html
+        and the corresponding testGeneiousExamplesTie test in test/test_dna.py
+    @param minCoverage: An C{int} minimum number of reads that must cover a
+        site for a threshold consensus base to be called. If zero reads
+        cover a site, the C{noCoverage} value is used or if the number is
+        greater than zero but less then C{minCoverage}, the C{lowCoverage}
+        value is used.
+    @param lowCoverage: A C{str} indicating what to do when some reads cover a
+        site, but fewer than C{minCoverage}. Either 'reference' or a single
+        character (e.g., 'N').
+    @param noCoverage: A C{str} indicating what to do when no reads cover a
+        reference base. Either 'reference' or a single character (e.g., 'N').
+    @return: A C{str} consensus sequence.
     """
-
-    print('TODO: This function is not finished yet.')
-    return
-
-    start = time()
-    if isinstance(recordFilename, str):
-        # TODO: REMOVE THE LIMIT IN THE NEXT LINE!
-        allhits = findHits(recordFilename, set([hitId]), limit=100)
-    else:
-        allhits = recordFilename
-    sequence = getSequence(hitId, db)
-    fasta, summary = summarizeHits(allhits, fastaFilename, eCutoff=eCutoff)
-    minX, maxX = summary['minX'], summary['maxX']
-    if actualSequenceId:
-        # UNUSED.
-        # actualSequence = getSequence(actualSequenceId, db)
-        pass
-    print(summary['hitCount'])
-    print('seq len =', len(sequence))
-    fasta = summary['fasta']
-    # The length of the consensus depends on where the query sequences fell
-    # when aligned with the target. The consensus could extend the target
-    # at both ends.
-    consensusLen = maxX - minX
-    consensus = [None, ] * consensusLen
-    for item in summary['items']:
-        print('NEW HSP')
-        printHSP(item['origHsp'])  # TODO: REMOVE ME
-        hsp = item['hsp']
-        print('HIT query-start=%d query-stop=%d subj-start=%d subj-stop=%d' % (
-            hsp['queryStart'], hsp['queryEnd'], hsp['subjectStart'],
-            hsp['subjectEnd']))
-        # print '   match: %s%s' % ('.' * hsp['subjectStart'], '-' *
-        # (hsp['subjectEnd'] - hsp['subjectStart']))
-        if item['frame']['subject'] > 0:
-            query = fasta[item['sequenceId']].seq
+    with samfile(bamFilename) as fp:
+        if strategy == 'majority':
+            return _majorityConsensus(fp, reference, threshold, minCoverage,
+                                      lowCoverage, noCoverage)
         else:
-            query = fasta[item['sequenceId']].reverse_complement().seq
-        print('       target:',
-              sequence[hsp['queryStart']:hsp['queryEnd']].seq)
-        print('        query:', query)
-        match = []
-        for index in range(hsp['subjectStart'], hsp['subjectEnd']):
-            queryIndex = index - hsp['queryStart']
-            match.append('.' if query[queryIndex] == sequence[index] else '*')
-        print('        match: %s%s' % (
-            ' ' * (hsp['subjectStart'] - hsp['queryStart']), ''.join(match)))
-        print('        score:', item['convertedE'])
-        print('    match len:', hsp['subjectEnd'] - hsp['subjectStart'])
-        print('subject frame:', item['frame']['subject'])
-        for queryIndex, sequenceIndex in enumerate(
-                range(hsp['queryStart'], hsp['queryEnd'])):
-            consensusIndex = sequenceIndex + minX
-            locus = consensus[consensusIndex]
-            if locus is None:
-                consensus[consensusIndex] = locus = defaultdict(int)
-            locus[query[queryIndex]] += 1
+            raise ValueError(f'Unknown consensus strategy {strategy!r}.')
 
-    # Print the consensus before the target, if any.
-    for index in range(minX, 0):
-        consensusIndex = index - minX
-        if consensus[consensusIndex]:
-            print('%d: %r' % (index, consensus[consensusIndex]))
-    # Print the consensus as it overlaps with the target, if any.
-    for index in range(0, len(sequence)):
-        consensusIndex = index - minX
-        try:
-            if consensus[consensusIndex]:
-                print('%d: %r (%s)' % (
-                    index, consensus[index], sequence[index]))
-        except KeyError:
-            # There's nothing left in the consensus, so we're done.
-            break
-    for index in range(len(sequence), maxX):
-        consensusIndex = index - minX
-        if consensus[consensusIndex]:
-            print('%d: %r' % (index, consensus[consensusIndex]))
-    stop = time()
-    report('Consensus sequence generated in %.3f mins.' %
-           ((stop - start) / 60.0))
-    return summary, consensus
+
+def _majorityConsensus(bam, reference, threshold, minCoverage, lowCoverage,
+                       noCoverage):
+    """
+    Compute a majority consensus.
+
+    @param bam: An open BAM file.
+    @param reference: A C{dark.reads.Read} instance giving the reference
+        sequence.
+    @param threshold: A C{float} threshold. If the majority ...
+    @param minCoverage: An C{int} minimum number of reads that must cover a
+        site for a threshold consensus base to be called. If zero reads
+        cover a site, the C{noCoverage} value is used or if the number is
+        greater than zero but less then C{minCoverage}, the C{lowCoverage}
+        value is used.
+    @param lowCoverage: A C{str} indicating what to do when some reads cover a
+        site, but fewer than C{minCoverage}. Either 'reference' or a single
+        character (e.g., 'N').
+    @param noCoverage: A C{str} indicating what to do when no reads cover a
+        reference base. Either 'reference' or a single character (e.g., 'N').
+    @return: A C{str} consensus sequence.
+    """
+    result = list(reference.sequence if noCoverage == 'reference' else
+                  noCoverage * len(reference))
+    lowCoverage = (reference.sequence if lowCoverage == 'reference' else
+                   lowCoverage * len(reference))
+
+    for column in bam.pileup(reference=reference.id):
+        site = column.reference_pos
+        bases = defaultdict(int)
+        readCount = 0
+        for read in column.pileups:
+            readCount += 1
+            base = read.alignment.query_sequence[read.query_position]
+            bases[base] += 1
+            # quality = read.alignment.query_qualities[read.query_position]
+
+        result[site] = (lowCoverage[site] if readCount < minCoverage else
+                        leastAmbiguousFromCounts(bases, threshold))
+
+    return ''.join(result)

--- a/dark/sam.py
+++ b/dark/sam.py
@@ -4,11 +4,13 @@ import numpy as np
 from json import dump, load
 from contextlib import contextmanager
 from collections import Counter, defaultdict
+from subprocess import CalledProcessError
 
 from pysam import (
     AlignmentFile, CMATCH, CINS, CDEL, CREF_SKIP, CSOFT_CLIP, CHARD_CLIP, CPAD,
     CEQUAL, CDIFF)
 
+from dark.process import Executor
 from dark.reads import Read, DNARead
 
 
@@ -39,6 +41,20 @@ def samfile(filename):
     f = AlignmentFile(filename)
     yield f
     f.close()
+
+
+def samtoolsInstalled():
+    """
+    Test if samtools is installed.
+
+    @return: A C{bool}, which is C{True} if DIAMOND seems to be installed.
+    """
+    try:
+        Executor().execute('samtools help')
+    except CalledProcessError:
+        return False
+    else:
+        return True
 
 
 def samReferences(filenameOrSamfile):

--- a/test/test_consensus.py
+++ b/test/test_consensus.py
@@ -1,0 +1,285 @@
+from unittest import TestCase, skipUnless
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import mkdtemp
+
+from dark.consensus import consensusFromBAM
+from dark.process import Executor
+from dark.reads import DNARead
+from dark.sam import samtoolsInstalled
+
+
+@contextmanager
+def makeBAM(template):
+    """
+    A context manager decorator to make a simple BAM file from a template.
+
+    @param template: An iterable of C{str} sequences. The first will be treated
+        as the reference, and then subsequent pairs (if any) will be treated as
+        read and quality strings. Reads and quality strings can be indented
+        with spaces to show where the read aligns with the reference (as would
+        be produced by a tool like bowtie2 or bwa).
+    @return: A context manager that produces a reference sequence and the name
+        of the BAM file.
+    """
+    e = Executor()
+    dirname = mkdtemp(prefix='test-consensus-')
+    refId = 'ref-id'
+    try:
+        samFile = Path(dirname) / 'file.sam'
+        bamFile = Path(dirname) / 'file.bam'
+        reference = DNARead(refId, template[0])
+        assert (len(template) % 2) == 1
+        nSeqs = (len(template) - 1) >> 1
+
+        with open(samFile, 'w') as fp:
+            print(f'@SQ\tSN:{refId}\tLN:{len(template[0])}', file=fp)
+
+            for count in range(nSeqs):
+                read = template[count * 2 + 1].rstrip()
+                quality = template[count * 2 + 2].rstrip()
+                assert len(read) == len(quality)
+                query = read.lstrip()
+                quality = quality.lstrip()
+                matchOffset = len(read) - len(query)
+                print('\t'.join(map(str, (
+                    f'read{count}',  # QUERY ID
+                    0,  # FLAGS
+                    refId,  # REF ID
+                    matchOffset + 1,  # POS
+                    30,  # MAPQ
+                    f'{len(query)}M',  # CIGAR
+                    '=',  # MRNM (Mate reference name)
+                    1,  # MPOS (Mate position)
+                    0,  # ISIZE
+                    query,
+                    quality,
+                ))), file=fp)
+
+        # e.execute(f'cat {samFile}')
+        e.execute(f'samtools view -b -o {str(bamFile)!r} {str(samFile)!r}')
+        e.execute(f'samtools index {str(bamFile)!r}')
+        yield (reference, bamFile)
+    finally:
+        e.execute(f'rm -fr {dirname!r}')
+
+
+@skipUnless(samtoolsInstalled(), 'samtools is not installed')
+class TestMajority(TestCase):
+    """
+    Test making majority consensuses.
+    """
+    def testNoReadsReference(self):
+        """
+        If no reads are present and resolution of no-coverage bases is the
+        reference sequence, the reference should be returned.
+        """
+        template = ('ACGTTCCG',)
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual(template[0],
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              noCoverage='reference'))
+
+    def testNoReadsN(self):
+        """
+        If no reads are present and resolution of no-coverage bases is 'N'
+        (or '?', etc) a sequence of Ns (or ?s, etc) should be returned.
+        """
+        template = ('ACGTTCCG',)
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            for char in 'N?':
+                self.assertEqual(char * len(template[0]),
+                                 consensusFromBAM(bamFilename, reference,
+                                                  strategy='majority',
+                                                  noCoverage=char))
+
+    def testLowReadsReference(self):
+        """
+        If fewer reads than needed are present and resolution of low-coverage
+        bases is the reference sequence, the reference should be returned.
+        """
+        template = ('ACGTTCCG',
+                    '  GTT',
+                    '  ???',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual(template[0],
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              lowCoverage='reference',
+                                              minCoverage=2))
+
+    def testLowReadsCharNoCoverageConsensus(self):
+        """
+        If fewer reads than needed are present and resolution of low-coverage
+        bases is 'N' (or '? etc), then Ns (or ?s, etc) should be returned in
+        the low coverage sites, and the reference in the sites with no
+        coverage.
+        """
+        template = ('ACGTTCCG',
+                    '  GTT',
+                    '  ???',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            for char in 'N?':
+                self.assertEqual('AC' + char * 3 + 'CCG',
+                                 consensusFromBAM(bamFilename, reference,
+                                                  strategy='majority',
+                                                  lowCoverage=char,
+                                                  minCoverage=2))
+
+    def testLowReadsCharNoCoverageX(self):
+        """
+        If fewer reads than needed are present and resolution of low-coverage
+        bases is 'N' (or '? etc), then Ns (or ?s, etc) should be returned in
+        the low coverage sites, and (for example) 'X' in the sites with no
+        coverage.
+        """
+        template = ('ACGTTCCG',
+                    '  GTT',
+                    '  ???',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            for char in 'N?':
+                self.assertEqual('XX' + char * 3 + 'XXX',
+                                 consensusFromBAM(bamFilename, reference,
+                                                  strategy='majority',
+                                                  noCoverage='X',
+                                                  lowCoverage=char,
+                                                  minCoverage=2))
+
+    def testOneReadMatchingPartOfTheReference(self):
+        """
+        If one read is present and it matches part of the reference and
+        resolution of no-coverage bases is the reference sequence, the
+        reference should be returned.
+        """
+        template = ('ACGTTCCG',
+                    '  GTT',
+                    '  ???',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual(template[0],
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              noCoverage='reference'))
+
+    def testOneReadDifferingFromPartOfTheReference(self):
+        """
+        If one read is present and it differs from part of the reference and
+        resolution of no-coverage bases is the reference sequence, the
+        expected hybrid of the read and the reference should be returned.
+        """
+        template = ('ACGTTCCG',
+                    '  AAA',
+                    '  ???',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual('ACAAACCG',
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              noCoverage='reference'))
+
+    def testTwoReadsDifferingFromPartOfTheReferenceSomeLowCoverage(self):
+        """
+        If two reads are present and they differ from part of the reference and
+        resolution of no-coverage bases is the reference sequence, the
+        expected hybrid of the read and the reference should be returned, with
+        the part of the reads that has insufficient coverage returning the
+        low-coverage symbol (here '+').
+        """
+        template = ('ACGTTCCG',
+                    '  AAA',
+                    '  ???',
+                    '  AAAT',
+                    '  ????',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual('ACAAA+CG',
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              minCoverage=2,
+                                              noCoverage='reference',
+                                              lowCoverage='+'))
+
+    def testTwoReadsDifferingFromPartOfTheReferenceLowAndNoCoverage(self):
+        """
+        If two reads are present and they differ from part of the reference and
+        resolution of no-coverage bases is 'N', the expected hybrid of the read
+        and the reference should be returned, with the part of the reads that
+        has insufficient coverage returning the low-coverage symbol (here '+').
+        """
+        template = ('ACGTTCCG',
+                    '  AAA',
+                    '  ???',
+                    '  AAAT',
+                    '  ????',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual('NNAAA+NN',
+                             consensusFromBAM(bamFilename, reference,
+                                              strategy='majority',
+                                              minCoverage=2,
+                                              noCoverage='N',
+                                              lowCoverage='+'))
+
+    def testSimpleMajority(self):
+        """
+        If three reads result in a majority base at a site, that base should
+        be in the consensus.
+        """
+        template = ('ACGT',
+                    '  A',
+                    '  ?',
+                    '  A',
+                    '  ?',
+                    '  C',
+                    '  ?',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual('ACAT',
+                             consensusFromBAM(bamFilename, reference,
+                                              threshold=0.5,
+                                              strategy='majority'))
+
+    def testSimpleMajorityBelowThreshold(self):
+        """
+        If conflicting reads at a site do not give a simple (above threshold)
+        majority, the ambiguous code should be in the consensus.
+        """
+        template = ('ACGT',
+                    '  A',
+                    '  ?',
+                    '  A',
+                    '  ?',
+                    '  C',
+                    '  ?',
+                    )
+
+        with makeBAM(template) as data:
+            reference, bamFilename = data
+            self.assertEqual('ACMT',
+                             consensusFromBAM(bamFilename, reference,
+                                              threshold=0.7,
+                                              strategy='majority'))

--- a/test/test_dna.py
+++ b/test/test_dna.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 
 from dark.dna import (
     AMBIGUOUS, BASES_TO_AMBIGUOUS, compareDNAReads, matchToString,
-    findKozakConsensus, FloatBaseCounts, sequenceToRegex)
+    findKozakConsensus, FloatBaseCounts, sequenceToRegex, leastAmbiguous,
+    leastAmbiguousFromCounts)
 from dark.reads import Read, DNARead, DNAKozakRead
 
 # The following are the letters that used to be on
@@ -11,6 +12,11 @@ from dark.reads import Read, DNARead, DNAKozakRead
 # IUPACAmbiguousDNA.letters
 # But Bio.Alphabet is now deprecated and will be removed.
 AMBIGUOUS_DNA_LETTERS = 'GATCRYWSMKHBVDN'
+
+AMBIGUOUS_PAIRS = (('AC', 'M'), ('AG', 'R'), ('AT', 'W'),
+                   ('GC', 'S'), ('GT', 'K'), ('CT', 'Y'))
+
+AMBIGUOUS_TRIPLES = (('ACG', 'V'), ('ACT', 'H'), ('AGT', 'D'), ('CGT', 'B'))
 
 
 class TestAmbiguousLetters(TestCase):
@@ -1233,3 +1239,200 @@ class TestSequenceToRegex(TestCase):
         """
         error = "^'5'$"
         six.assertRaisesRegex(self, KeyError, error, sequenceToRegex, '5')
+
+
+class TestLeastAmbiguous(TestCase):
+    """
+    Test the leastAmbiguous function.
+    """
+    def testEmpty(self):
+        """
+        The empty string should result in a KeyError.
+        """
+        self.assertRaisesRegex(KeyError, "^''$", leastAmbiguous, '')
+
+    def testUnknownNucleotides(self):
+        """
+        Unknown nucleotides should result in a KeyError.
+        """
+        self.assertRaisesRegex(KeyError, "^'123'$", leastAmbiguous, '123')
+
+    def testDuplicationsIgnored(self):
+        """
+        If nucleotides are duplicated, there should be no problem.
+        """
+        self.assertEqual('A', leastAmbiguous('AAA'))
+
+    def testDuplicationsDifferentCaseIgnored(self):
+        """
+        If nucleotides are duplicated in different cases, there should be no
+        problem.
+        """
+        self.assertEqual('A', leastAmbiguous('AaaA'))
+
+    def testSingleNucleotides(self):
+        """
+        Single nucleotides should be returned as themselves.
+        """
+        for base in 'ACGT':
+            self.assertEqual(base, leastAmbiguous(base))
+
+    def testTwoNucleotides(self):
+        """
+        Two nucleotides should be handled correctly.
+        """
+        for bases, ambiguous in AMBIGUOUS_PAIRS:
+            self.assertEqual(ambiguous, leastAmbiguous(bases))
+
+    def testThreeNucleotides(self):
+        """
+        Three nucleotides should be handled correctly.
+        """
+        for bases, ambiguous in AMBIGUOUS_TRIPLES:
+            self.assertEqual(ambiguous, leastAmbiguous(bases))
+
+    def testFourNucleotides(self):
+        """
+        All four nucleotides should be handled correctly.
+        """
+        self.assertEqual('N', leastAmbiguous('AGCT'))
+
+    def testFourNucleotidesOtherOrder(self):
+        """
+        All four nucleotides should be handled correctly when given in a
+        different order.
+        """
+        self.assertEqual('N', leastAmbiguous('CGTA'))
+
+    def testTuple(self):
+        """
+        All four nucleotides passed as a tuple should be handled correctly.
+        """
+        self.assertEqual('N', leastAmbiguous(tuple('AGCT')))
+
+    def testList(self):
+        """
+        All four nucleotides passed as a list should be handled correctly.
+        """
+        self.assertEqual('N', leastAmbiguous(list('AGCT')))
+
+
+class TestLeastAmbiguousFromBases(TestCase):
+    """
+    Test the leastAmbiguousFromCounts function.
+    """
+    def testNegativeCount(self):
+        """
+        A negative count must result in a ValueError.
+        """
+        self.assertRaisesRegex(
+            ValueError, r"^Count for base 'A' is negative \(-1\)\.$",
+            leastAmbiguousFromCounts, {'A': -1}, 0.9)
+
+    def testNegativeThreshold(self):
+        """
+        A negative threshold must result in a ValueError.
+        """
+        self.assertRaisesRegex(
+            ValueError, r"^Threshold cannot be negative \(-0\.9\)\.$",
+            leastAmbiguousFromCounts, {'A': 3}, -0.9)
+
+    def testNoCounts(self):
+        """
+        If an empty dictionary of counts is passed, 'N' must result.
+        """
+        self.assertEqual('N', leastAmbiguousFromCounts({}, 0.9))
+
+    def testAllCountsZero(self):
+        """
+        If the counts are all zero, 'N' must result.
+        """
+        self.assertEqual('N', leastAmbiguousFromCounts({'A': 0, 'G': 0}, 0.9))
+
+    def testOneBase(self):
+        """
+        If there is a single base, it must be returned.
+        """
+        for base in 'ACGT':
+            self.assertEqual(base, leastAmbiguousFromCounts({base: 3}, 0.9))
+
+    def testTwoEqual(self):
+        """
+        If there are two bases with equal counts, the expected ambiguous code
+        must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_PAIRS:
+            counts = dict.fromkeys(bases, 1)
+            self.assertEqual(ambiguous, leastAmbiguousFromCounts(counts, 0.9))
+
+    def testThreeEqual(self):
+        """
+        If there are three bases with equal counts, the expected ambiguous code
+        must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_TRIPLES:
+            counts = dict.fromkeys(bases, 1)
+            self.assertEqual(ambiguous, leastAmbiguousFromCounts(counts, 0.9))
+
+    def testFourNucleotides(self):
+        """
+        If all four nucleotides have equal counts, 'N' must be returned.
+        """
+        counts = dict.fromkeys('AGCT', 1)
+        self.assertEqual('N', leastAmbiguousFromCounts(counts, 0.9))
+
+    def testOneOfTwoOverThreshold(self):
+        """
+        If one base of two is over the threshold, it must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_PAIRS:
+            counts = {bases[0]: 3, bases[1]: 1}
+            self.assertEqual(bases[0], leastAmbiguousFromCounts(counts, 0.5))
+
+    def testOneOfTwoBelowThreshold(self):
+        """
+        If one base is dominant but not over the threshold, the ambiguous code
+        must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_PAIRS:
+            counts = {bases[0]: 3, bases[1]: 1}
+            self.assertEqual(ambiguous, leastAmbiguousFromCounts(counts, 0.9))
+
+    def testOneOfThreeOverThreshold(self):
+        """
+        If one base of three is over the threshold, it must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_TRIPLES:
+            counts = {bases[0]: 3, bases[1]: 1, bases[2]: 1}
+            self.assertEqual(bases[0], leastAmbiguousFromCounts(counts, 0.5))
+
+    def testTwoOfThreeOverThreshold(self):
+        """
+        If two bases of three are over the threshold, the code for those two
+        must be returned.
+        """
+        for bases, ambiguous in AMBIGUOUS_TRIPLES:
+            counts = {bases[0]: 4, bases[1]: 4, bases[2]: 2}
+            self.assertEqual(
+                leastAmbiguous(bases[:2]),
+                leastAmbiguousFromCounts(counts, 0.8))
+
+    def testGeneiousExamplesNoTie(self):
+        """
+        Test the no-tied counts example from
+        https://assets.geneious.com/manual/2020.1/static/GeneiousManualse43.html
+        """
+        counts = {'A': 6, 'G': 3, 'T': 1}
+        self.assertEqual('A', leastAmbiguousFromCounts(counts, 0.4))
+        self.assertEqual('R', leastAmbiguousFromCounts(counts, 0.7))
+        self.assertEqual('D', leastAmbiguousFromCounts(counts, 0.95))
+
+    def testGeneiousExamplesTie(self):
+        """
+        Test the tied counts example from
+        https://assets.geneious.com/manual/2020.1/static/GeneiousManualse43.html
+        """
+        counts = {'A': 6, 'G': 2, 'T': 2}
+        self.assertEqual('A', leastAmbiguousFromCounts(counts, 0.4))
+        self.assertEqual('D', leastAmbiguousFromCounts(counts, 0.7))
+        self.assertEqual('D', leastAmbiguousFromCounts(counts, 0.95))


### PR DESCRIPTION
Here's a first pull request to add simple consensus generation from a BAM file.  I deleted the old code we had in `consensus.py` based on BLAST alignment results. I wrote that years ago and never finished it and it's now irrelevant.

TODO:
- Add more tests with different quality combinations.
- Make this usable from `make-consensus.py` (maybe I'll do that on the plane trip).

This is likely too simplistic in its treatment of BAM files. There are quite a few other things (based on SAM flags and the pysam processing) that could be a factor, though at this point I don't see why they would be and am not sure if they need to be considered. I think we'll have to try this and see how it goes and whether it breaks, etc.,

I had planned to make this a bit more general (with different `strategy` possibilities), but there may be no need, in which case the extra function in `dark/consensus.py` can just be merged into the main one.

This follows the treatment of quality scores used by Geneious, described at https://assets.geneious.com/manual/2020.1/static/GeneiousManualse43.html That may not be the best approach, but it is defensible (in a publication). Other options / nuances (and tests for them) could easi;y be added.

The testing framework is very basic, and may need to be made more sophisticated. But I was trying to get something simple working first. More might not be needed.