### PR TITLE
Fixed (hopefully!) a bug in bin/fasta-identity-table.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.76 March 14, 2024
+
+Fixed (hopefully!) a bug in `bin/fasta-identity-table.py` that could cause
+a `KeyError` when producing a non-square table,
+[as described here](https://github.com/acorg/dark-matter/issues/780).
+
 ## 4.0.75 March 12, 2024
 
 Moved `getNoCoverageCounts` from `bin/fasta-identity-table.py` into

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 6):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "4.0.75"
+__version__ = "4.0.76"


### PR DESCRIPTION
Fixes #780 in which a `KeyError` was raised when producing a non-square table.

There are many changes here as a result of cleaning up the code to use more informative names to distinguish between rows and columns. The key change is keeping a `dict` of row indices (for read ids) as well as one with column indices. That's a pretty small part of the overall editing.

There are no tests for any of this. That's because the code produces a potentially big HTML table. Some of it could have been broken out and tested, but I never did that... the code just grew and grew. And writing tests would involve creating FASTA files (or mocking FASTA files).

I have run this with the invocation that was causing the error and it no longer happens. For sure (IMO) such a key error can no longer happen, because the read ids from the second FASTA file are now put into their own `dict`, so cannot cause a `KeyError` if something tries to look them up in the `dict` for the first set of reads (the table rows). Hopefully I didn't break anything else in the process - don't think so.