### PR TITLE
Prevent an IndexError in bin/sam-reference-read-counts.py when there are no matching reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.77 March 15, 2024
+
+Prevent an `IndexError` in `bin/sam-reference-read-counts.py` when there
+are no matching reads.
+
 ## 4.0.76 March 14, 2024
 
 Fixed (hopefully!) a bug in `bin/fasta-identity-table.py` that could cause

--- a/bin/sam-reference-read-counts.py
+++ b/bin/sam-reference-read-counts.py
@@ -34,7 +34,7 @@ def main(args):
     """
     if args.topReferenceIdsFile and args.sortBy != "count":
         print(
-            "--topReferenceIdsFile only makes sense when using --sortBy " "count",
+            "--topReferenceIdsFile only makes sense when using --sortBy count",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -94,7 +94,7 @@ def main(args):
             return len(referenceReads[referenceId]["readIds"])
 
         sortedReferenceReads = sorted(referenceReads, key=key, reverse=True)
-        topReference = sortedReferenceReads[0]
+        topReference = sortedReferenceReads[0] if sortedReferenceReads else None
     else:
         # Sort the references by name
         sortedReferenceReads = sorted(referenceReads)
@@ -136,7 +136,11 @@ def main(args):
     # Write out the (sorted) read ids of the reference with the most reads.
     if args.topReferenceIdsFile:
         with open(args.topReferenceIdsFile, "w") as fp:
-            print("\n".join(sorted(referenceReads[topReference]["readIds"])), file=fp)
+            # Note that the file will be empty if there is no top reference.
+            if topReference:
+                print(
+                    "\n".join(sorted(referenceReads[topReference]["readIds"])), file=fp
+                )
 
 
 if __name__ == "__main__":

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 6):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "4.0.76"
+__version__ = "4.0.77"


### PR DESCRIPTION
Note that this is branched from #781 (awaiting @imLew review).

Fixes #782 
