### PR TITLE
Added --sortBy coverage option to bin/sam-reference-read-counts.py and moved much of its code into dark/sam.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.79 March 31, 2024
+
+Added `--sortBy coverage` option to `bin/sam-reference-read-counts.py` and
+moved much of its code into `dark/sam.py`.
+
 ## 4.0.77 March 15, 2024
 
 Prevent an `IndexError` in `bin/sam-reference-read-counts.py` when there

--- a/bin/sam-reference-read-counts.py
+++ b/bin/sam-reference-read-counts.py
@@ -2,27 +2,8 @@
 
 import sys
 import argparse
-from collections import defaultdict
 
-from dark.sam import samfile, SAMFilter
-from dark.utils import pct
-
-
-def referenceInfo():
-    """
-    Hold information about the reads that match a reference.
-
-    @return: A C{dict}, as below.
-    """
-    return {
-        "duplicate": set(),
-        "primary": set(),
-        "qcFail": set(),
-        "nonDuplicate": set(),
-        "readIds": set(),
-        "secondary": set(),
-        "supplementary": set(),
-    }
+from dark.sam import ReadsSummary
 
 
 def main(args):
@@ -32,123 +13,38 @@ def main(args):
     @param args: An argparse namespace with information about parsed
         command-line options.
     """
-    if args.topReferenceIdsFile and args.sortBy != "count":
+    if args.topReferenceIdsFile and args.sortBy == "name":
         print(
-            "--topReferenceIdsFile only makes sense when using --sortBy count",
+            "--topReferenceIdsFile only makes sense when sorting by count or coverage",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    referenceReads = defaultdict(referenceInfo)
-    mapped = set()
-    unmapped = set()
-    readIds = set()
-
-    referenceLengths = SAMFilter(args.samFile).referenceLengths()
-
-    with samfile(args.samFile) as fp:
-        for read in fp.fetch():
-            id_ = read.query_name
-            readIds.add(id_)
-            if read.is_unmapped:
-                unmapped.add(id_)
-            else:
-                mapped.add(id_)
-                stats = referenceReads[read.reference_name]
-                stats["readIds"].add(id_)
-
-                if read.is_secondary:
-                    stats["secondary"].add(id_)
-                elif read.is_supplementary:
-                    stats["supplementary"].add(id_)
-                else:
-                    stats["primary"].add(id_)
-
-                if read.is_duplicate:
-                    stats["duplicate"].add(id_)
-                else:
-                    stats["nonDuplicate"].add(id_)
-
-                if read.is_qcfail:
-                    stats["qcFail"].add(id_)
-
-    totalReads = len(readIds)
+    summary = ReadsSummary(args.samFile)
 
     print(
-        "Found a total of %d read%s (%d mapped, %d unmapped) mapping "
-        "against %d of %d reference%s."
-        % (
-            totalReads,
-            "" if totalReads == 1 else "s",
-            len(mapped),
-            len(unmapped),
-            len(referenceReads),
-            len(referenceLengths),
-            "" if len(referenceLengths) == 1 else "s",
+        summary.toString(
+            excludeZeroes=args.excludeZeroes,
+            excludeIfNoAdditional=args.excludeIfNoAdditional,
+            sortBy=args.sortBy,
         )
     )
 
-    if args.sortBy == "count":
-
-        def key(referenceId):
-            return len(referenceReads[referenceId]["readIds"])
-
-        sortedReferenceReads = sorted(referenceReads, key=key, reverse=True)
-        topReference = sortedReferenceReads[0] if sortedReferenceReads else None
-    else:
-        # Sort the references by name
-        sortedReferenceReads = sorted(referenceReads)
-
-    cumulativeReadIds = set()
-
-    for count, referenceId in enumerate(sortedReferenceReads, start=1):
-        stats = referenceReads[referenceId]
-        readCount = len(stats["readIds"])
-        if readCount == 0 and args.excludeZeroes:
-            continue
-        newReadCount = len(stats["readIds"] - cumulativeReadIds)
-        if newReadCount == 0 and args.excludeIfNoAdditional:
-            continue
-        cumulativeReadIds.update(stats["readIds"])
-        print(
-            "\nReference %d: %s (%d nt):\n"
-            "  Overall reads mapped to the reference: %s\n"
-            "  Non-duplicates: %s, Duplicates: %s, QC fails: %s\n"
-            "  Primary: %s, Secondary: %s, Supplementary: %s\n"
-            "  Reads not matching any reference above: %s\n"
-            "  Previously unmatched reads for this reference: %s"
-            % (
-                count,
-                referenceId,
-                referenceLengths[referenceId],
-                pct(readCount, totalReads),
-                pct(len(stats["nonDuplicate"]), readCount),
-                pct(len(stats["duplicate"]), readCount),
-                pct(len(stats["qcFail"]), readCount),
-                pct(len(stats["primary"]), readCount),
-                pct(len(stats["secondary"]), readCount),
-                pct(len(stats["supplementary"]), readCount),
-                pct(newReadCount, totalReads),
-                pct(newReadCount, readCount),
-            )
-        )
-
-    # Write out the (sorted) read ids of the reference with the most reads.
+    # Write out the sorted read ids of the top reference.
     if args.topReferenceIdsFile:
         with open(args.topReferenceIdsFile, "w") as fp:
-            # Note that the file will be empty if there is no top reference.
-            if topReference:
-                print(
-                    "\n".join(sorted(referenceReads[topReference]["readIds"])), file=fp
-                )
+            print("\n".join(sorted(summary.sortedReferences[0].readIds)), file=fp)
 
 
-if __name__ == "__main__":
+def makeParser():
+    """
+    Make an argument parser.
+
+    @return: An C{argparse} argument parser.
+    """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description=(
-            "Print SAM/BAM file reference sequence and unmapped read " "counts."
-        ),
+        description="Print SAM/BAM file reference sequence and unmapped read counts.",
     )
 
     parser.add_argument(
@@ -157,12 +53,13 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--sortBy",
-        choices=("count", "name"),
+        choices=("count", "coverage", "name"),
         default="count",
         help=(
-            'Use "count" to sort the output by decreasing read count (i.e., '
+            "Use 'count' to sort the output by decreasing read count (i.e., "
             "the reference with the highest number of matching reads is "
-            'printed first), or "name" to sort by reference name.'
+            "printed first), or 'coverage' to sort by decreasing genome "
+            "coverage, or 'name' to sort by reference name."
         ),
     )
 
@@ -194,4 +91,8 @@ if __name__ == "__main__":
         ),
     )
 
-    main(parser.parse_args())
+    return parser
+
+
+if __name__ == "__main__":
+    main(makeParser().parse_args())

--- a/bin/sam-reference-read-counts.py
+++ b/bin/sam-reference-read-counts.py
@@ -13,7 +13,7 @@ def main(args):
     @param args: An argparse namespace with information about parsed
         command-line options.
     """
-    if args.topReferenceIdsFile and args.sortBy == "name":
+    if args.topReferenceIdsFile and args.sortBy not in ("count", "coverage"):
         print(
             "--topReferenceIdsFile only makes sense when sorting by count or coverage",
             file=sys.stderr,

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 6):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "4.0.77"
+__version__ = "4.0.79"

--- a/dark/aligners.py
+++ b/dark/aligners.py
@@ -235,7 +235,7 @@ def removeUnnecessaryGaps(
             return seq1, seq2
 
     raise RuntimeError(
-        "Fell off the end of removeFirstUnnecessaryGaps. " "This should be impossible!"
+        "Fell off the end of removeFirstUnnecessaryGaps. This should be impossible!"
     )
 
 

--- a/dark/alignments.py
+++ b/dark/alignments.py
@@ -466,7 +466,7 @@ class ReadsAlignments:
             subclass.
         """
         raise NotImplementedError(
-            "getSubjectSequence must be implemented by " "a subclass"
+            "getSubjectSequence must be implemented by a subclass"
         )
 
     def hsps(self) -> Generator[Union[HSP, LSP], None, None]:

--- a/dark/bowtie2.py
+++ b/dark/bowtie2.py
@@ -47,7 +47,7 @@ class Bowtie2:
             # complain). We do things this way to allow a user to use TAB
             # completion on the command line to give them the full path to
             # any bowtie index file.
-            for suffix in ("1.bt2 2.bt2 3.bt2 4.bt2 rev.1.bt2 " "rev.2.bt2").split():
+            for suffix in ("1.bt2 2.bt2 3.bt2 4.bt2 rev.1.bt2 rev.2.bt2").split():
                 suffix = "." + suffix
                 if index.endswith(suffix):
                     self._indexFile = index[: -len(suffix)]
@@ -359,7 +359,7 @@ class Bowtie2:
         )
 
         if self._reference is None:
-            self._report("Will use this FASTA file as the reference " "(if needed).")
+            self._report("Will use this FASTA file as the reference (if needed).")
             self._reference = fastaFilename
 
         return index

--- a/dark/cigar.py
+++ b/dark/cigar.py
@@ -222,7 +222,7 @@ def softClippedOffset(offset, pairs, cigarOperations):
 
     # This should be impossible.
     raise ValueError(
-        "Soft-clipped base with no following or preceding " "non-hard-clipped bases."
+        "Soft-clipped base with no following or preceding non-hard-clipped bases."
     )
 
 
@@ -269,4 +269,4 @@ def insertionOffset(offset, pairs, cigarOperations):
                 return False, referenceOffset
 
     # This should be impossible.
-    raise ValueError("Inserted base with no following or preceding " "reference bases.")
+    raise ValueError("Inserted base with no following or preceding reference bases.")

--- a/dark/civ/graphics.py
+++ b/dark/civ/graphics.py
@@ -224,7 +224,7 @@ def alignmentGraph(
                 for read in reads:
                     if read in readColor:
                         raise ValueError(
-                            "Read %s is specified multiple " "times in idList" % read
+                            "Read %s is specified multiple times in idList" % read
                         )
                     else:
                         readColor[read] = color

--- a/dark/civ/proteins.py
+++ b/dark/civ/proteins.py
@@ -2362,10 +2362,10 @@ class SqliteIndexWriter:
         """
         cur = self._connection.cursor()
         cur.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS protein_idx ON " "proteins(accession)"
+            "CREATE UNIQUE INDEX IF NOT EXISTS protein_idx ON proteins(accession)"
         )
         cur.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS genomes_idx ON " "genomes(accession)"
+            "CREATE UNIQUE INDEX IF NOT EXISTS genomes_idx ON genomes(accession)"
         )
         self._connection.commit()
         self._connection.close()

--- a/dark/fasta_ss.py
+++ b/dark/fasta_ss.py
@@ -59,7 +59,7 @@ class SSFastaReads(Reads):
                         structureRecord = next(records)
                     except StopIteration:
                         raise ValueError(
-                            "Structure file %r has an odd number " "of records." % _file
+                            "Structure file %r has an odd number of records." % _file
                         )
 
                     if len(structureRecord) != len(record):

--- a/dark/features.py
+++ b/dark/features.py
@@ -219,7 +219,7 @@ class _FeatureAdder:
             for plotting.
         """
         raise NotImplementedError(
-            "_displayFeatures must be implemented in " "a subclass."
+            "_displayFeatures must be implemented in a subclass."
         )
 
 

--- a/dark/filter.py
+++ b/dark/filter.py
@@ -280,7 +280,6 @@ def addFASTAFilteringCommandLineOptions(parser):
     _removeGroup.add_argument(
         "--removeDuplicates",
         action="store_true",
-        default=False,
         help=(
             "Duplicate reads will be removed, based only on "
             "sequence identity. The first occurrence is kept."
@@ -290,7 +289,6 @@ def addFASTAFilteringCommandLineOptions(parser):
     _removeGroup.add_argument(
         "--removeDuplicatesById",
         action="store_true",
-        default=False,
         help=(
             "Duplicate reads will be removed, based only on "
             "read id. The first occurrence is kept."
@@ -300,7 +298,6 @@ def addFASTAFilteringCommandLineOptions(parser):
     parser.add_argument(
         "--removeDuplicatesUseMD5",
         action="store_true",
-        default=False,
         help=(
             "MD5 sums will be stored instead of the full sequence or read "
             "id when either --removeDuplicates or removeDuplicatesById are "
@@ -518,14 +515,12 @@ def addFASTAEditingCommandLineOptions(parser):
     parser.add_argument(
         "--reverse",
         action="store_true",
-        default=False,
-        help=("Reverse the sequences. Note that this is NOT reverse " "complementing."),
+        help="Reverse the sequences. Note that this is NOT reverse complementing.",
     )
 
     parser.add_argument(
         "--reverseComplement",
         action="store_true",
-        default=False,
         help="Reverse complement the sequences.",
     )
 

--- a/dark/graphics.py
+++ b/dark/graphics.py
@@ -400,7 +400,7 @@ def alignmentGraph(
                 for read in reads:
                     if read in readColor:
                         raise ValueError(
-                            "Read %s is specified multiple " "times in idList" % read
+                            "Read %s is specified multiple times in idList" % read
                         )
                     else:
                         readColor[read] = color

--- a/dark/mutations.py
+++ b/dark/mutations.py
@@ -29,7 +29,7 @@ def basePlotter(blastHits, title):
     result = []
     params = blastHits.plotParams
     assert params is not None, (
-        "Oops, it looks like you forgot to run " "computePlotInfo."
+        "Oops, it looks like you forgot to run computePlotInfo."
     )
 
     sequence = ncbidb.getSequence(title, blastHits.records.blastDb)
@@ -40,7 +40,7 @@ def basePlotter(blastHits, title):
 
     plotInfo = blastHits.titles[title]["plotInfo"]
     assert plotInfo is not None, (
-        "Oops, it looks like you forgot to run " "computePlotInfo."
+        "Oops, it looks like you forgot to run computePlotInfo."
     )
 
     items = plotInfo["items"]

--- a/dark/reads.py
+++ b/dark/reads.py
@@ -168,7 +168,7 @@ class Read:
                     self.quality,
                 )
         else:
-            raise ValueError("Format must be either 'fasta', 'fastq' or " "'fasta-ss'.")
+            raise ValueError("Format must be either 'fasta', 'fastq' or 'fasta-ss'.")
 
     def toDict(self) -> dict:
         """
@@ -575,7 +575,7 @@ class AARead(Read):
         readLetters = super().checkAlphabet(count)
         if len(self) > 10 and readLetters.issubset(set("ACGT")):
             raise ValueError(
-                "It looks like a DNA sequence has been passed to " "AARead()."
+                "It looks like a DNA sequence has been passed to AARead()."
             )
         return readLetters
 
@@ -1161,7 +1161,7 @@ class ReadFilter:
 
             if trueLength is None:
                 raise ValueError(
-                    "trueLength must be supplied if randomSubset " "is specified."
+                    "trueLength must be supplied if randomSubset is specified."
                 )
 
         self.minLength = minLength
@@ -1996,7 +1996,7 @@ def addFASTACommandLineOptions(parser: argparse.ArgumentParser) -> None:
         "--fasta",
         default=False,
         action="store_true",
-        help=("If specified, input will be treated as FASTA. This is the " "default."),
+        help="If specified, input will be treated as FASTA. This is the default.",
     )
 
     group.add_argument(

--- a/dark/sam.py
+++ b/dark/sam.py
@@ -391,28 +391,24 @@ class SAMFilter:
 
         parser.add_argument(
             "--dropUnmapped",
-            default=False,
             action="store_true",
             help="If given, unmapped matches will not be output.",
         )
 
         parser.add_argument(
             "--dropSecondary",
-            default=False,
             action="store_true",
             help="If given, secondary matches will not be output.",
         )
 
         parser.add_argument(
             "--dropSupplementary",
-            default=False,
             action="store_true",
             help="If given, supplementary matches will not be output.",
         )
 
         parser.add_argument(
             "--dropDuplicates",
-            default=False,
             action="store_true",
             help=(
                 "If given, matches flagged as optical or PCR duplicates "
@@ -422,7 +418,6 @@ class SAMFilter:
 
         parser.add_argument(
             "--keepQCFailures",
-            default=False,
             action="store_true",
             help=(
                 "If given, reads that are considered quality control "

--- a/dark/sam.py
+++ b/dark/sam.py
@@ -1391,7 +1391,7 @@ class ReadsSummary:
         @param sortBy: A C{str} indicating how to sort. Use 'count' to sort by
             decreasing read count (i.e., the reference with the highest number
             of matching reads comes first), or 'coverage' to sort by decreasing
-            genome coverage, or 'name' to sort by reference name."
+            genome coverage, or 'name' to sort by reference name.
         @return: A C{list} of sorted C{ReferenceReads} instances.
         """
         totalReads = len(self.readIds)
@@ -1461,7 +1461,8 @@ class ReadsSummary:
         @param sortBy: A C{str} indicating how to sort. Use 'count' to sort by
             decreasing read count (i.e., the reference with the highest number
             of matching reads comes first), or 'coverage' to sort by decreasing
-            genome coverage, or 'name' to sort by reference name."
+            genome coverage, or 'name' to sort by reference name.
+        @raise AssertionError: If C{sortBy} has an unknown value.
         @return: A C{list} of sorted C{ReferenceReads} instances.
         """
         if self.sortedBy == sortBy:
@@ -1481,6 +1482,7 @@ class ReadsSummary:
 
         else:
             # Sort by name.
+            assert sortBy == "name", f"Unknown sortBy value {sortBy!r}."
             reverse = False
 
             def key(reference):

--- a/dark/sam.py
+++ b/dark/sam.py
@@ -1480,13 +1480,14 @@ class ReadsSummary:
             def key(reference):
                 return reference.coverage(), len(reference.readIds)
 
-        else:
-            # Sort by name.
-            assert sortBy == "name", f"Unknown sortBy value {sortBy!r}."
+        elif sortBy == "name":
             reverse = False
 
             def key(reference):
                 return reference.id_, len(reference.readIds), reference.coverage()
+
+        else:
+            raise ValueError(f"Unknown sortBy value {sortBy!r}.")
 
         self.sortedReferences = sorted(self.references.values(), key=key, reverse=reverse)
         self.sortedBy = sortBy

--- a/dark/titles.py
+++ b/dark/titles.py
@@ -311,7 +311,7 @@ class TitlesAlignments(dict):
         """
         if title in self:
             raise KeyError(
-                "Title %r already present in TitlesAlignments " "instance." % title
+                "Title %r already present in TitlesAlignments instance." % title
             )
         else:
             self[title] = titleAlignments

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
     packages=["dark", "dark.blast", "dark.diamond", "dark.civ"],
     url="https://github.com/acorg/dark-matter",
     download_url="https://github.com/acorg/dark-matter",
-    author="Terry Jones, Barbara Mühlemann, Tali Veith, Sophie Mathias, Udo Gieraths",
+    author="Terry Jones, Barbara Mühlemann, Tali Veith, Sophie Mathias, Udo Gieraths, Nikolai Zaki",
     author_email="tcj25@cam.ac.uk",
     keywords=["virus discovery"],
     classifiers=[

--- a/test/blast/test_alignments.py
+++ b/test/blast/test_alignments.py
@@ -470,7 +470,7 @@ class TestBlastReadsAlignments(TestCase):
                 cur.execute("INSERT INTO files(name) VALUES (?)", ("xxx.fasta",))
                 fileNumber = cur.lastrowid
                 cur.execute(
-                    "INSERT INTO sequences(id, " "fileNumber, offset) VALUES (?, ?, ?)",
+                    "INSERT INTO sequences(id, fileNumber, offset) VALUES (?, ?, ?)",
                     ("seqid", fileNumber, 7),
                 )
                 connection.commit()

--- a/test/diamond/sample_proteins.py
+++ b/test/diamond/sample_proteins.py
@@ -63,7 +63,7 @@ SAMPLE_DATA = {
             ),
         },
         "AM282986.1": {
-            "id": ("Hepatitis B virus (SUBTYPE ADW2), genotype A, complete " "genome"),
+            "id": ("Hepatitis B virus (SUBTYPE ADW2), genotype A, complete genome"),
             "genome": (
                 "TTCCACTGCCTTCCACCAAGCTCTGCAGGATCCCAAAGTCAGGGGTCTGTATTTTCCTGC"
                 "TGGTGGCTCCAGTTCAGGAACAGTAAACCCTGCTCCGAATATTGCCTCTCACATCTCGTC"

--- a/test/test_bowtie2.py
+++ b/test/test_bowtie2.py
@@ -21,12 +21,12 @@ class TestBowtie2(TestCase):
         bt = Bowtie2(executor=e, dryRun=True, verboseFp=fp)
         bt.buildIndex("MN908947.3")
         self.assertEqual(
-            "$ bowtie2-build --quiet '/tmp/xxx/MN908947.3.fasta' " "'/tmp/xxx/index'",
+            "$ bowtie2-build --quiet '/tmp/xxx/MN908947.3.fasta' '/tmp/xxx/index'",
             e.log[-1],
         )
         log = fp.getvalue()
         self.assertTrue(
-            log.startswith("Downloading FASTA for accession MN908947.3 " "from NCBI.\n")
+            log.startswith("Downloading FASTA for accession MN908947.3 from NCBI.\n")
         )
 
     @patch("os.path.exists")
@@ -258,7 +258,7 @@ class TestBowtie2(TestCase):
         log = fp.getvalue()
         self.assertTrue(log.endswith("\nConverting SAM to BAM.\n"))
         self.assertEqual(
-            "$ samtools view -b  '/tmp/xxx/result.sam' > " "'/tmp/xxx/result.bam'",
+            "$ samtools view -b  '/tmp/xxx/result.sam' > '/tmp/xxx/result.bam'",
             e.log[-1],
         )
 
@@ -299,7 +299,7 @@ class TestBowtie2(TestCase):
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/non-duplicates.sam' " "'/tmp/xxx/result.sam'", e.log[-1]
+            "$ mv '/tmp/xxx/non-duplicates.sam' '/tmp/xxx/result.sam'", e.log[-1]
         )
 
     @patch("os.path.exists")
@@ -317,11 +317,11 @@ class TestBowtie2(TestCase):
         log = fp.getvalue()
         self.assertTrue(log.endswith("\nSorting SAM (by coord).\n"))
         self.assertEqual(
-            "$ samtools sort '/tmp/xxx/result.sam' > " "'/tmp/xxx/result-sorted.sam'",
+            "$ samtools sort '/tmp/xxx/result.sam' > '/tmp/xxx/result-sorted.sam'",
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/result-sorted.sam' " "'/tmp/xxx/result.sam'", e.log[-1]
+            "$ mv '/tmp/xxx/result-sorted.sam' '/tmp/xxx/result.sam'", e.log[-1]
         )
 
     @patch("os.path.exists")
@@ -344,7 +344,7 @@ class TestBowtie2(TestCase):
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/result-sorted.sam' " "'/tmp/xxx/result.sam'", e.log[-1]
+            "$ mv '/tmp/xxx/result-sorted.sam' '/tmp/xxx/result.sam'", e.log[-1]
         )
 
     @patch("os.path.exists")
@@ -425,7 +425,7 @@ class TestBowtie2(TestCase):
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/picard-duplicates.bam' " "'/tmp/xxx/result.bam'", e.log[-1]
+            "$ mv '/tmp/xxx/picard-duplicates.bam' '/tmp/xxx/result.bam'", e.log[-1]
         )
 
     @patch("os.path.exists")
@@ -451,7 +451,7 @@ class TestBowtie2(TestCase):
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/gatk-duplicates.bam' " "'/tmp/xxx/result.bam'", e.log[-1]
+            "$ mv '/tmp/xxx/gatk-duplicates.bam' '/tmp/xxx/result.bam'", e.log[-1]
         )
 
     @patch("os.path.exists")
@@ -478,7 +478,7 @@ class TestBowtie2(TestCase):
             e.log[-2],
         )
         self.assertEqual(
-            "$ mv '/tmp/xxx/gatk-duplicates.bam' " "'/tmp/xxx/result.bam'", e.log[-1]
+            "$ mv '/tmp/xxx/gatk-duplicates.bam' '/tmp/xxx/result.bam'", e.log[-1]
         )
 
     def testClose(self):

--- a/test/test_fasta.py
+++ b/test/test_fasta.py
@@ -570,7 +570,7 @@ class TestSqliteIndex(TestCase):
     """
 
     def testAddFilename(self):
-        """ "
+        """
         Test the internal _addFilename method.
         """
         index = SqliteIndex(":memory:")
@@ -579,7 +579,7 @@ class TestSqliteIndex(TestCase):
         index.close()
 
     def testAddDuplicateFilename(self):
-        """ "
+        """
         When _addFilename is called twice with the same name, a ValueError
         must be raised.
         """
@@ -589,7 +589,7 @@ class TestSqliteIndex(TestCase):
         assertRaisesRegex(self, ValueError, error, index._addFilename, "f.fas")
 
     def testGetNonexistentFilename(self):
-        """ "
+        """
         If the internal _getFilename method is called with a file number that
         has not been added, it must return None.
         """
@@ -598,7 +598,7 @@ class TestSqliteIndex(TestCase):
         index.close()
 
     def testGetFilename(self):
-        """ "
+        """
         The internal _getFilename method must return the expected result.
         """
         index = SqliteIndex(":memory:")
@@ -607,7 +607,7 @@ class TestSqliteIndex(TestCase):
         index.close()
 
     def testGetNonexistentFileNumber(self):
-        """ "
+        """
         If the internal _getFileNumber method is called with a file whose name
         has not been added, it must return None.
         """
@@ -616,7 +616,7 @@ class TestSqliteIndex(TestCase):
         index.close()
 
     def testGetFileNumber(self):
-        """ "
+        """
         The internal _getFileNumber method must return the expected result.
         """
         index = SqliteIndex(":memory:")
@@ -625,7 +625,7 @@ class TestSqliteIndex(TestCase):
         index.close()
 
     def testBZ2File(self):
-        """ "
+        """
         Trying to add a .bz2 file must result in a ValueError.
         """
         index = SqliteIndex(":memory:")
@@ -636,7 +636,7 @@ class TestSqliteIndex(TestCase):
         assertRaisesRegex(self, ValueError, error, index.addFile, "file.bz2")
 
     def testAddOneFile(self):
-        """ "
+        """
         Test the creation of an index with sequences added from one file.
         """
 
@@ -664,7 +664,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testAddFileWithDuplicateSequence(self):
-        """ "
+        """
         If a sequence id is duplicated in a FASTA file, a ValueError must be
         raised.
         """
@@ -690,13 +690,13 @@ class TestSqliteIndex(TestCase):
             mockMethod.side_effect = sideEffect
             index = SqliteIndex(":memory:")
             error = (
-                "^FASTA sequence id 'id1' found twice in file " "'filename.fasta'\\.$"
+                "^FASTA sequence id 'id1' found twice in file 'filename.fasta'\\.$"
             )
             assertRaisesRegex(self, ValueError, error, index.addFile, "filename.fasta")
             index.close()
 
     def testAddFilesWithDuplicateSequence(self):
-        """ "
+        """
         If a sequence id occurs in more than one FASTA file, a ValueError must
         be raised.
         """
@@ -735,7 +735,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testAddDuplicateFile(self):
-        """ "
+        """
         If a filename is passed to addFile more than once, a ValueError must
         be raised.
         """
@@ -768,7 +768,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testFind(self):
-        """ "
+        """
         The _find method must return the expected filename and offset.
         """
 
@@ -798,7 +798,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testFindWithTwoFiles(self):
-        """ "
+        """
         The _find method must return the expected filename and offset when
         sequences are added from two files.
         """
@@ -835,7 +835,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupSequenceCrossesNewlines(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read when the sequence spans multiple lines of the input file,
         including lines ending in \n and \r\n.
@@ -866,7 +866,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupWithFastaDirectory(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read, obtained from the expected file name, when a FASTA base
         directory is specified.
@@ -903,7 +903,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupSequenceLastInFile(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read when the sequence spans multiple lines and is the last
         one in the input file.
@@ -934,7 +934,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupSequenceMiddleOfThree(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read when the sequence spans multiple lines and is the middle
         one of three sequences in the input file.
@@ -965,7 +965,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupWithTwoFiles(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected reads when sequences are added from two files.
         """
@@ -1002,7 +1002,7 @@ class TestSqliteIndex(TestCase):
             index.close()
 
     def testDictLookupSpecificReadClass(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read type.
         """
@@ -1035,7 +1035,7 @@ class TestSqliteIndex(TestCase):
 
     @skip("Skipped until fix in matplotlib is released")
     def testDictLookupGzipDataWithBGZsuffix(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected read when the index file is in BGZF format and has a .bgz
         suffix.
@@ -1073,7 +1073,7 @@ class TestSqliteIndex(TestCase):
 
     @skip("Skipped until fix in matplotlib is released")
     def testDictLookupGzipData(self):
-        """ "
+        """
         The __getitem__ method (i.e., dictionary-like lookup) must return the
         expected reads when sequences span multiple lines of the input file,
         and include lines ending in \n and \r\n and have been compressed with

--- a/test/test_fasta_ss.py
+++ b/test/test_fasta_ss.py
@@ -29,7 +29,7 @@ class TestSSFastaReads(TestCase):
         """
         data = "\n".join([">seq1", "REDD", ">str1", "HH--", ">seq2", "REAA"])
         with patch.object(builtins, "open", mock_open(read_data=data)):
-            error = "^Structure file 'x.fasta' has an odd number of " "records\\.$"
+            error = "^Structure file 'x.fasta' has an odd number of records\\.$"
             six.assertRaisesRegex(
                 self, ValueError, error, list, SSFastaReads("x.fasta")
             )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -196,7 +196,7 @@ class TestParseRangeString(TestCase):
         """
         An empty string must produce an empty set of indices.
         """
-        error = "^Illegal range ''. Ranges must single numbers or " "number-number\\.$"
+        error = "^Illegal range ''. Ranges must single numbers or number-number\\.$"
         assertRaisesRegex(self, ValueError, error, parseRangeString, "")
 
     def testSingleNumber(self):


### PR DESCRIPTION
I also cleaned up many concatenated strings that were put next to each other on the same line by `black`.