### PR TITLE
Added sequence filtering options to filter-fasta.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.0.80 April 20, 2024
+
+Added `--sequenceWhitelist`, `--sequenceBlacklist`,
+`--sequenceWhitelistFile`, `--sequenceBlacklistFile`, `--sequenceRegex`,
+and `--sequenceNegativeRegex` arguments to `filter-fasta.py` to match the
+corresponding options for sequence titles (ids).
+
 ## 4.0.79 March 31, 2024
 
 Added `--sortBy coverage` option to `bin/sam-reference-read-counts.py` and

--- a/bin/format-fasta.py
+++ b/bin/format-fasta.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description=(
-            "Given FASTA on stdin, write it to stdout according to a " "given format."
+            "Given FASTA on stdin, write it to stdout according to a given format."
         )
     )
 

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 6):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "4.0.79"
+__version__ = "4.0.80"


### PR DESCRIPTION
Added --sequenceWhitelist, --sequenceBlacklist, --sequenceWhitelistFile, --sequenceBlacklistFile, --sequenceRegex, and --sequenceNegativeRegex arguments to filter-fasta.py to match the corresponding options for sequence titles (ids).

So you can now do things like `filter-fasta.py --sequenceNegativeRegex '[^ACGT]'` to filter out sequences that have ambiguous nucleotide codes.