### PR TITLE
Added stdout and stderr arguments to dark.process.Executor and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.87 July 20, 2024
+
+Added `stdout` and `stderr` options to `dark.process.Executor` to allow
+for simple printing of executed commands and their outputs.
+
 ## 4.0.86 June 15, 2024
 
 Added `bin/fasta-split-by-length.py`.

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 6):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "4.0.86"
+__version__ = "4.0.87"

--- a/dark/process.py
+++ b/dark/process.py
@@ -2,16 +2,6 @@ import sys
 from time import time, ctime
 from subprocess import PIPE, CalledProcessError, run
 
-# Singleton object to indicate no file descriptor. This allows the user to pass None to
-# the 'execute' method to indicate that stdout and stderr should not be written to any
-# file descriptor, as opposed to defaulting to using the Executor instance value of
-# self.stdout self.stderr. I.e., this is just another version of None, which allows the
-# user to use the normal Python None as a valid value indicating a non-default behaviour
-# (because the default behaviour is to use self.stdout or self.stderr). I hope that
-# makes sense! If you can think of a simpler way to do this, go for it - but make sure
-# the tests all still pass :-)
-_NONE = object()
-
 
 class Executor:
     """
@@ -30,7 +20,7 @@ class Executor:
         self.dryRun = dryRun
         self.stdout = stdout
         self.stderr = stderr
-        self.log = [f"# Executor created at {ctime(time())}. Dry run = dryRun."]
+        self.log = [f"# Executor created at {ctime(time())}. Dry run = {dryRun}."]
 
     def dryRun(self):
         """
@@ -41,7 +31,7 @@ class Executor:
         return self._dryRun
 
     def execute(
-        self, command, dryRun=None, useStderr=True, stdout=_NONE, stderr=_NONE, **kwargs
+        self, command, dryRun=None, useStderr=True, stdout=False, stderr=False, **kwargs
     ):
         """
         Execute (or simulate) a command. Add to our log.
@@ -74,13 +64,8 @@ class Executor:
             C{returncode}, C{stdout}, and C{stderr}. See pydoc subprocess.
             If C{dryRun} is C{True}, C{None} is returned.
         """
-        stdout = self.stdout if stdout is _NONE else stdout
-        stderr = self.stderr if stderr is _NONE else stderr
-
-        # In case you have difficulty with the logic above, the following might
-        # be reassuring (both values are either a valid file descriptor or None).
-        assert stdout is not _NONE
-        assert stderr is not _NONE
+        stdout = self.stdout if stdout is False else stdout
+        stderr = self.stderr if stderr is False else stderr
 
         if isinstance(command, str):
             # Can't have newlines in a command given to the shell.
@@ -91,7 +76,7 @@ class Executor:
             shell = False
 
         if stdout:
-            print(strCommand, file=stdout)
+            print("$ " + strCommand, file=stdout)
 
         dryRun = self.dryRun if dryRun is None else dryRun
 

--- a/dark/process.py
+++ b/dark/process.py
@@ -1,26 +1,36 @@
-import six
+import sys
 from time import time, ctime
+from subprocess import PIPE, CalledProcessError, run
 
-from subprocess import PIPE, CalledProcessError
-
-if six.PY3:
-    from subprocess import run
-else:
-    from subprocess import check_call
+# Singleton object to indicate no file descriptor. This allows the user to pass None to
+# the 'execute' method to indicate that stdout and stderr should not be written to any
+# file descriptor, as opposed to defaulting to using the Executor instance value of
+# self.stdout self.stderr. I.e., this is just another version of None, which allows the
+# user to use the normal Python None as a valid value indicating a non-default behaviour
+# (because the default behaviour is to use self.stdout or self.stderr). I hope that
+# makes sense! If you can think of a simpler way to do this, go for it - but make sure
+# the tests all still pass :-)
+_NONE = object()
 
 
 class Executor:
     """
     Log and execute shell commands.
 
-    @param dryRun: If C{True}, do not execute commands, just log them.
-        This sets the default and can be overidden for a specific command
-        by passing C{dryRun} to the C{execute} method.
+    @param dryRun: If C{True}, do not execute commands, just log them. This sets the
+        default and can be overidden for a specific command by passing C{dryRun} to
+        the C{execute} method.
+    @stdout: If not C{None}, must be an open file descriptor. Both the commands that
+        are executed and their standard output will be written to this descriptor.
+    @stderr: If not C{None}, must be an open file descriptor. The standard error output
+        of commands will be written to this descriptor.
     """
 
-    def __init__(self, dryRun=False):
+    def __init__(self, dryRun=False, stdout=None, stderr=None):
         self.dryRun = dryRun
-        self.log = ["# Executor created at %s. Dry run = %s." % (ctime(time()), dryRun)]
+        self.stdout = stdout
+        self.stderr = stderr
+        self.log = [f"# Executor created at {ctime(time())}. Dry run = dryRun."]
 
     def dryRun(self):
         """
@@ -30,7 +40,9 @@ class Executor:
         """
         return self._dryRun
 
-    def execute(self, command, dryRun=None, useStderr=True, **kwargs):
+    def execute(
+        self, command, dryRun=None, useStderr=True, stdout=_NONE, stderr=_NONE, **kwargs
+    ):
         """
         Execute (or simulate) a command. Add to our log.
 
@@ -40,28 +52,46 @@ class Executor:
         @param dryRun: If C{True}, do not execute commands, just log them.
             If C{False}, execute the commands. If not given or C{None}, use
             the default setting (in C{self.dryRun}).
-        @param useStderr: If C{True} print a summary of the command standard
-            output and standard error to sys.stderr if the command results in
-            an exception. If a function is passed, the exception is passed to
-            the function and the summary is printed to sys.stderr if the
-            function returns C{True}.
-        @param kwargs: Keyword arguments that will be passed to subprocess.run
-            (or subprocess.check_call for Python version 2). Note that keyword
-            arguments are not currently logged (the logging is slightly
-            problematic since a keyword argument might be an environment
-            dictionary).
+        @param useStderr: If C{True} and the command results in an exception, print
+            a summary of the command standard output and standard error to sys.stderr.
+            If a function is passed, the exception is passed to the function and the
+            summary is printed to sys.stderr if the function returns C{True}.
+        @stdout: If not C{None}, must be an open file descriptor. Both the
+            commands that are executed and their standard output will be written
+            to this descriptor. If C{None}, output will not be written to any
+            descriptor (but remains available on the result object, as usual). If no
+            value is passed, the value originally passed to __init__ will be used.
+        @stderr: If not C{None}, must be an open file descriptor. The standard
+            error output of commands will be written to this descriptor.  If C{None},
+            stderr output will not be written to any descriptor (but remains available
+            on the result object, as usual). If no value is passed, the value
+            originally passed to __init__ will be used.
+        @param kwargs: Keyword arguments that will be passed to subprocess.run. Note
+            that keyword arguments are not currently logged (the logging is slightly
+            problematic since a keyword argument might be an environment dictionary).
         @raise CalledProcessError: If the command results in an error.
         @return: A C{CompletedProcess} instance. This has attributes such as
             C{returncode}, C{stdout}, and C{stderr}. See pydoc subprocess.
             If C{dryRun} is C{True}, C{None} is returned.
         """
-        if isinstance(command, six.string_types):
+        stdout = self.stdout if stdout is _NONE else stdout
+        stderr = self.stderr if stderr is _NONE else stderr
+
+        # In case you have difficulty with the logic above, the following might
+        # be reassuring (both values are either a valid file descriptor or None).
+        assert stdout is not _NONE
+        assert stderr is not _NONE
+
+        if isinstance(command, str):
             # Can't have newlines in a command given to the shell.
             strCommand = command = command.replace("\n", " ").strip()
             shell = True
         else:
             strCommand = " ".join(command)
             shell = False
+
+        if stdout:
+            print(strCommand, file=stdout)
 
         dryRun = self.dryRun if dryRun is None else dryRun
 
@@ -77,47 +107,24 @@ class Executor:
             ]
         )
 
-        if six.PY3:
-            try:
-                result = run(
-                    command,
-                    check=True,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    shell=shell,
-                    universal_newlines=True,
-                    **kwargs
-                )
-            except CalledProcessError as e:
-                if callable(useStderr):
-                    useStderr = useStderr(e)
-                if useStderr:
-                    import sys
-
-                    print("CalledProcessError:", e, file=sys.stderr)
-                    print("STDOUT:\n%s" % e.stdout, file=sys.stderr)
-                    print("STDERR:\n%s" % e.stderr, file=sys.stderr)
-                raise
-        else:
-            try:
-                result = check_call(
-                    command,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    shell=shell,
-                    universal_newlines=True,
-                    **kwargs
-                )
-            except CalledProcessError as e:
-                if callable(useStderr):
-                    useStderr = useStderr(e)
-                if useStderr:
-                    import sys
-
-                    print("CalledProcessError:", e, file=sys.stderr)
-                    print("Return code: %s" % e.returncode, file=sys.stderr)
-                    print("Output:\n%s" % e.output, file=sys.stderr)
-                raise
+        try:
+            result = run(
+                command,
+                check=True,
+                stdout=PIPE,
+                stderr=PIPE,
+                shell=shell,
+                universal_newlines=True,
+                **kwargs,
+            )
+        except CalledProcessError as e:
+            if callable(useStderr):
+                useStderr = useStderr(e)
+            if useStderr:
+                print("CalledProcessError:", e, file=sys.stderr)
+                print("STDOUT:\n%s" % e.stdout, file=sys.stderr)
+                print("STDERR:\n%s" % e.stderr, file=sys.stderr)
+            raise
 
         stop = time()
         elapsed = stop - start
@@ -127,5 +134,11 @@ class Executor:
                 "# Elapsed = %f seconds" % elapsed,
             ]
         )
+
+        if result.stdout and stdout:
+            print(result.stdout, end="", file=stdout)
+
+        if result.stderr and stderr:
+            print(result.stderr, end="", file=stderr)
 
         return result

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -1,8 +1,6 @@
-import sys
-import six
-from unittest import TestCase, skipUnless
-from six import assertRaisesRegex
+from unittest import TestCase
 from subprocess import CalledProcessError
+from io import StringIO
 
 from dark.process import Executor
 
@@ -19,13 +17,8 @@ class TestProcess(TestCase):
         e = Executor()
         # Presumably there will not be an executable with this name!
         command = "/".join(["dev", "non-existent", "@" * 20])
-        error = r"^Command '%s' returned non-zero exit status 127%s$" % (
-            command,
-            "" if sys.version_info < (3, 6) else r"\.",
-        )
-        assertRaisesRegex(
-            self, CalledProcessError, error, e.execute, command, useStderr=False
-        )
+        error = rf"^Command '{command}' returned non-zero exit status 127\.$"
+        self.assertRaisesRegex(CalledProcessError, error, e.execute, command)
 
     def testDryRunTrue(self):
         """
@@ -57,7 +50,6 @@ class TestProcess(TestCase):
         self.assertIsNone(result)
         self.assertEqual("$ date", e.log[-1])
 
-    @skipUnless(six.PY3, "subprocess output skipped under PY2")
     def testEchoStr(self):
         """
         We should be able to call echo using a string command.
@@ -67,7 +59,6 @@ class TestProcess(TestCase):
         self.assertEqual("hello", result.stdout.strip())
         self.assertTrue("$ echo hello" in e.log)
 
-    @skipUnless(six.PY3, "subprocess output skipped under PY2")
     def testEchoList(self):
         """
         We should be able to call echo using a list command.
@@ -77,7 +68,6 @@ class TestProcess(TestCase):
         self.assertEqual("hello", result.stdout.strip())
         self.assertTrue("$ echo hello" in e.log)
 
-    @skipUnless(six.PY3, "subprocess output skipped under PY2")
     def testPipe(self):
         """
         We should be able to pipe echo into wc -c.
@@ -86,3 +76,78 @@ class TestProcess(TestCase):
         result = e.execute("echo hello | wc -c")
         self.assertEqual("6", result.stdout.strip())
         self.assertTrue("$ echo hello | wc -c" in e.log)
+
+    def testPassStdoutFileDescriptorDryRun(self):
+        """
+        Passing a file descriptor for stdout when in dry run mode must result
+        in the command being written to that descriptor.
+        """
+        stdout = StringIO()
+        e = Executor(stdout=stdout, dryRun=True)
+        e.execute("echo hello")
+        self.assertEqual("echo hello\n", stdout.getvalue())
+
+    def testPassStdoutFileDescriptor(self):
+        """
+        Passing a file descriptor for stdout must result in the
+        command and its output being written to that descriptor.
+        """
+        stdout = StringIO()
+        e = Executor(stdout=stdout)
+        e.execute("echo hello")
+        self.assertEqual("echo hello\nhello\n", stdout.getvalue())
+
+    def testPassStdoutFileDescriptorToExecute(self):
+        """
+        Passing a file descriptor for stdout in the call to execute must
+        result in the command and its output being written to that descriptor.
+        """
+        stdout = StringIO()
+        e = Executor()
+        e.execute("echo hello", stdout=stdout)
+        self.assertEqual("echo hello\nhello\n", stdout.getvalue())
+
+    def testPassNoneStdoutFileDescriptorToExecute(self):
+        """
+        Passing None for stdout in the call to execute must result in the
+        command and its output NOT being written to the corresponding option
+        passed to the class __init__ (i.e., it must be possible to override
+        the default for the class instance).
+        """
+        stdout = StringIO()
+        e = Executor(stdout=stdout)
+        e.execute("echo hello", stdout=None)
+        self.assertEqual("", stdout.getvalue())
+
+    def testPassStderrFileDescriptor(self):
+        """
+        Passing a file descriptor for stderr must result in the
+        standard error output being written to that descriptor.
+        """
+        stderr = StringIO()
+        e = Executor(stderr=stderr)
+        e.execute("echo hello >&2")
+        self.assertEqual("hello\n", stderr.getvalue())
+
+    def testPassStderrFileDescriptorToExecute(self):
+        """
+        Passing a file descriptor for stderr in the call to execute must
+        result in the standard error output being written to that descriptor.
+        """
+        stderr = StringIO()
+        e = Executor()
+        e.execute("echo hello >&2", stderr=stderr)
+        self.assertEqual("hello\n", stderr.getvalue())
+
+    def testPassStdoutAndStderrFileDescriptors(self):
+        """
+        Passing file descriptors for stdout and stderr must result in the
+        command and the standard output being written to the former and the
+        standard error being written to the latter.
+        """
+        stdout = StringIO()
+        stderr = StringIO()
+        e = Executor(stdout=stdout, stderr=stderr)
+        e.execute("echo one; echo two >&2")
+        self.assertEqual("echo one; echo two >&2\none\n", stdout.getvalue())
+        self.assertEqual("two\n", stderr.getvalue())

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -85,7 +85,7 @@ class TestProcess(TestCase):
         stdout = StringIO()
         e = Executor(stdout=stdout, dryRun=True)
         e.execute("echo hello")
-        self.assertEqual("echo hello\n", stdout.getvalue())
+        self.assertEqual("$ echo hello\n", stdout.getvalue())
 
     def testPassStdoutFileDescriptor(self):
         """
@@ -95,7 +95,7 @@ class TestProcess(TestCase):
         stdout = StringIO()
         e = Executor(stdout=stdout)
         e.execute("echo hello")
-        self.assertEqual("echo hello\nhello\n", stdout.getvalue())
+        self.assertEqual("$ echo hello\nhello\n", stdout.getvalue())
 
     def testPassStdoutFileDescriptorToExecute(self):
         """
@@ -105,7 +105,7 @@ class TestProcess(TestCase):
         stdout = StringIO()
         e = Executor()
         e.execute("echo hello", stdout=stdout)
-        self.assertEqual("echo hello\nhello\n", stdout.getvalue())
+        self.assertEqual("$ echo hello\nhello\n", stdout.getvalue())
 
     def testPassNoneStdoutFileDescriptorToExecute(self):
         """
@@ -149,5 +149,5 @@ class TestProcess(TestCase):
         stderr = StringIO()
         e = Executor(stdout=stdout, stderr=stderr)
         e.execute("echo one; echo two >&2")
-        self.assertEqual("echo one; echo two >&2\none\n", stdout.getvalue())
+        self.assertEqual("$ echo one; echo two >&2\none\n", stdout.getvalue())
         self.assertEqual("two\n", stderr.getvalue())


### PR DESCRIPTION
Removed Python2 support from dark.process

BTW, I consider the default behaviour of the Executor to be wrong. It should print unless told not to, but does things the other way around. I didn't change it, so as to maintain backwards compatibility (I mean in output). We could consider making an improved `Executor2` class, and drop the clunky /rarely-used `useStderr` arg to `execute` too.

Anyway, this pr makes the change you asked for, @imLew.