### PR TITLE
Add special-purpose script to add labels to unlabeled nodes in iqtree2 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.0.13 November 3, 2024
+
+Added `bin/add-support-to-iqtree2-issue-343.py` script for adding support
+labels to nodes in trees produced by `iqtree2` when (if not run with
+`-keep-ident`) it adds nodes and tips for identical sequences. `iqtree2`
+currently does not put a support label on (the edge leading to) the tip in
+the original processing or onto the nodes introduced by adding tips for the
+identical sequences. This is described in the `iqtree2` GitHub [issue
+343](https://github.com/iqtree/iqtree2/issues/343).
+
 ## 5.0.11 October 30, 2024
 
 Added `--rotate` and `--maxWindows` options to `window-split-alignment.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.11 October 26, 2024
+## 5.0.11 October 30, 2024
 
 Added `--rotate` and `--maxWindows` options to `window-split-alignment.py`.
 

--- a/bin/add-support-to-iqtree2-issue-343.py
+++ b/bin/add-support-to-iqtree2-issue-343.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import dendropy
+
+# See https://jeetsukumaran.github.io/DendroPy/schemas/index.html for the available
+# formats.
+FORMATS = {"newick", "nexml", "nexus", "phylip"}
+
+
+def parseArgs():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="""Special-purpose script to add support labels to nodes in
+trees produced by `iqtree2` when (if not run with `-keep-ident`) it adds nodes and tips
+for identical sequences. iqtree2 currently does not put a support label on (the edge
+leading to) the tip in the original processingor onto the nodes introduced by adding
+tips for the identical sequences.  This is described at
+https://github.com/iqtree/iqtree2/issues/343 The adjusted tree is written to standard
+output in the same format as the input tree (as specified by --format argument).""",
+    )
+
+    parser.add_argument(
+        "treeFile",
+        help="The tree file to examine.",
+    )
+
+    parser.add_argument(
+        "--support",
+        default="100",
+        help="The support label to add to unlabeled internal nodes",
+    )
+
+    parser.add_argument(
+        "--format",
+        default="newick",
+        choices=sorted(FORMATS),
+        help="The input (and resulting output) tree format.",
+    )
+
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print information about the number of nodes to which a label was added.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """
+    Add a label (a support value) to internal nodes with no label and print the
+    resultant tree to standard output.
+    """
+    args = parseArgs()
+
+    kwargs = (
+        dict(preserve_underscores=True) if args.format in {"newick", "nexus"} else {}
+    )
+    with open(args.treeFile) as fp:
+        tree = dendropy.Tree.get(file=fp, schema=args.format, **kwargs)
+
+    changes = 0
+
+    for node in tree.preorder_internal_node_iter():
+        if node.label is None:
+            if node is not tree.seed_node:
+                childLengths = [child.edge.length for child in node.child_nodes()]
+                if childLengths != [0.0, 0.0]:
+                    exit(
+                        "Internal node found with edges to its children that are not "
+                        f"all zero length (but instead, {', '.join(childLengths)}. "
+                        "Are you sure this tree was produced by iqtree2?"
+                    )
+                node.label = args.support
+                changes += 1
+
+    if args.verbose:
+        if changes:
+            s = "" if changes == 1 else "s"
+            print(
+                f"Added label {args.support!r} to {changes} node{s}.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "No unlabeled nodes were found. The input and output trees will be "
+                "identical.",
+                file=sys.stderr,
+            )
+
+    tree.write(file=sys.stdout, schema=args.format)
+
+
+if __name__ == "__main__":
+    main()

--- a/dark/__init__.py
+++ b/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 9):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "5.0.11"
+__version__ = "5.0.13"

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ scripts = [
     "bin/aa-to-dna.py",
     "bin/aa-to-properties.py",
     "bin/adaptor-distances.py",
+    "bin/add-support-to-iqtree2-issue-343.py",
     "bin/alignment-panel-civ.py",
     "bin/alignments-per-read.py",
     "bin/bit-score-to-e-value.py",


### PR DESCRIPTION
Added `bin/add-support-to-iqtree2-issue-343.py` script for adding support labels to nodes in trees produced by `iqtree2` when (if not run with`-keep-ident`) it adds nodes and tips for identical sequences. `iqtree2` currently does not put a support label on (the edge leading to) the tip in the original processing or onto the nodes introduced by adding tips for the identical sequences. This is described in the `iqtree2` GitHub [issue 343](https://github.com/iqtree/iqtree2/issues/343).
