### PR TITLE
Improve bin/sam-coverage-depth.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.39 June 10, 2025
+
+Improve `bin/sam-coverage-depth.py` by a) being more flexible on finding the
+reference sequence, b) ignoring (and warning about) non-ACGT nucleotides in
+reads found by pysam in the BAM, and c) correcting the read counts.
+
 ## 5.0.38 June 4, 2025
 
 Add printing of aa properties to `bin/aa-compare.py` (renamed from

--- a/src/dark/__init__.py
+++ b/src/dark/__init__.py
@@ -7,4 +7,4 @@ if sys.version_info < (3, 9):
 # otherwise it will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = "5.0.38"
+__version__ = "5.0.39"


### PR DESCRIPTION
By a) being more flexible on finding the reference sequence, b) ignoring (and warning about) non-ACGT nucleotides in reads found by pysam in the BAM, and c) correcting the read counts.